### PR TITLE
Fix: Healthcheck in GH workflow

### DIFF
--- a/.github/scripts/wait_for_service.sh
+++ b/.github/scripts/wait_for_service.sh
@@ -9,7 +9,7 @@ if [ ! -n "$SERVICE_NAME" ]; then
 fi
 
 for i in $(seq 1 $MAX_RETRY_COUNT); do
-  if [ "$(docker inspect -f '{{.State.Health.Status}}' "swissgeol-viewer-app-$SERVICE_NAME-1")" == "healthy" ]; then
+  if [ "$(docker inspect -f '{{.State.Health.Status}}' "swissgeol-viewer-suite-$SERVICE_NAME-1")" == "healthy" ]; then
     echo "Service $SERVICE_NAME is healthy!"
     exit 0
   else

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   api:
-    image: swissgeol-viewer-app/api:local
+    image: swissgeol-viewer-suite/api:local
     build:
       context: ./api
       dockerfile: DockerfileDev
@@ -19,7 +19,7 @@ services:
       - .env
 
   ui:
-    image: swissgeol-viewer-app/ui:local
+    image: swissgeol-viewer-suite/ui:local
     build:
       context: ./ui
       dockerfile: DockerfileDev


### PR DESCRIPTION
Due to this repository being renamed, the name of Docker services being started inside of GitHub Actions have changed to being prefixed by `swissgeol-viewer-suite` insteadof ``swissgeol-viewer-app`. This now causes the API Test job in the [Code Quality Workflow](https://github.com/swisstopo/swissgeol-viewer-suite/actions/workflows/code-quality.yml) to fail.

This PR fixes this issue. Note that after this change has been merged, every currently open PR should be rebased onto `develop` so its checks can run through before being merged.