### PR TITLE
Fix: Add ui core components to build output

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,7 +10,6 @@
         "@aws-sdk/client-s3": "3.758.0",
         "@aws-sdk/credential-provider-cognito-identity": "3.768.0",
         "@aws-sdk/s3-request-presigner": "3.758.0",
-        "@fontsource/inter": "^5.2.5",
         "@geoblocks/cesium-view-cube": "0.1.4",
         "@geoblocks/ga-search": "0.0.22",
         "@lit/context": "^1.1.3",
@@ -3493,15 +3492,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@fontsource/inter": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.5.tgz",
-      "integrity": "sha512-kbsPKj0S4p44JdYRFiW78Td8Ge2sBVxi/PIBwmih+RpSXUdvS9nbs1HIiuUSPtRMi14CqLEZ/fbk7dj7vni1Sg==",
-      "license": "OFL-1.1",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@geoblocks/cesium-view-cube": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -29,7 +29,6 @@
     "@aws-sdk/client-s3": "3.758.0",
     "@aws-sdk/credential-provider-cognito-identity": "3.768.0",
     "@aws-sdk/s3-request-presigner": "3.758.0",
-    "@fontsource/inter": "^5.2.5",
     "@geoblocks/cesium-view-cube": "0.1.4",
     "@geoblocks/ga-search": "0.0.22",
     "@lit/context": "^1.1.3",

--- a/ui/src/style/index.css
+++ b/ui/src/style/index.css
@@ -2,8 +2,7 @@
 
 @import "cesium/Build/Cesium/Widgets/widgets.css";
 
-@import "@fontsource/inter/index.css";
-@import '@swisstopo/swissgeol-ui-core/styles.css';
+@import "@swisstopo/swissgeol-ui-core/styles.css";
 @import "fomantic-ui-css/components/reset.css";
 @import "fomantic-ui-css/components/message.css";
 @import "fomantic-ui-css/components/list.css";

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -4,8 +4,6 @@ import { fileURLToPath } from 'url';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 import babel from '@rollup/plugin-babel';
 import inlinesvg from 'postcss-inline-svg';
-import cssimport from 'postcss-import';
-import postcssurl from 'postcss-url';
 import analyzer from 'vite-bundle-analyzer';
 
 // @ts-expect-error
@@ -25,9 +23,6 @@ export default defineConfig({
       ),
       './fomantic-ui-css': normalizePath(
         resolve(__dirname, 'node_modules/fomantic-ui-css'),
-      ),
-      './@fontsource/inter': normalizePath(
-        resolve(__dirname, 'node_modules/@fontsource/inter'),
       ),
       src: normalizePath(resolve(__dirname, 'src')),
     },
@@ -132,16 +127,15 @@ export default defineConfig({
           dest: './cesium/Widgets',
         },
         { src: 'locales/**/*', dest: './locales' },
-        { src: 'node_modules/@fontsource/inter/files/**/*', dest: 'fonts' },
-        {
-          src: 'node_modules/fomantic-ui-css/themes/default/assets/fonts/**/*',
-          dest: 'fonts',
-        },
         { src: 'manuals/dist/**/*', dest: './manuals' },
         { src: 'manuals/style.css', dest: './manuals' },
         { src: 'manuals/images/**/*', dest: './manuals/images' },
         {
           src: 'node_modules/@swisstopo/swissgeol-ui-core/dist/swissgeol-ui-core/assets/*',
+          dest: 'assets',
+        },
+        {
+          src: 'node_modules/@swisstopo/swissgeol-ui-core/dist/components/*',
           dest: 'assets',
         },
       ],
@@ -151,19 +145,7 @@ export default defineConfig({
   ].filter(Boolean),
   css: {
     postcss: {
-      plugins: [
-        inlinesvg(),
-        cssimport({
-          plugins: [
-            postcssurl([
-              {
-                filter: '**/*.+(woff|woff2)',
-                url: (asset) => `fonts/${asset.url.split('/').pop()}`,
-              },
-            ]),
-          ],
-        }),
-      ],
+      plugins: [inlinesvg()],
     },
   },
 });


### PR DESCRIPTION
Components from `swissgeol-ui-core` are loaded dynamically at runtime. Our build process didn't account for this, resulting in them not being included in the build process. This PR fixes this by adding a configuration to Vite which includes these files.

Additionally, the PR removes some of the fonts that have been superseded by the core library.