### PR TITLE
Fix build path for `swissgeol-ui-core`

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -135,7 +135,7 @@ export default defineConfig({
           dest: 'assets',
         },
         {
-          src: 'node_modules/@swisstopo/swissgeol-ui-core/dist/components/*',
+          src: 'node_modules/@swisstopo/swissgeol-ui-core/dist/esm/*',
           dest: 'assets',
         },
       ],


### PR DESCRIPTION
The Vite build used the wrong path for the lazy-loaded components...