### PR TITLE
Handle nullable input selector

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -14,7 +14,7 @@
         "@geoblocks/ga-search": "0.0.22",
         "@lit/context": "^1.1.3",
         "@lit/task": "^1.0.1",
-        "@swisstopo/swissgeol-ui-core": "^2.1.1",
+        "@swisstopo/swissgeol-ui-core": "^1.0.0",
         "cesium": "1.123.1",
         "d3-array": "3.2.4",
         "d3-axis": "3.0.0",
@@ -5010,9 +5010,9 @@
       }
     },
     "node_modules/@swisstopo/swissgeol-ui-core": {
-      "version": "2.1.1",
-      "resolved": "https://npm.pkg.github.com/download/@swisstopo/swissgeol-ui-core/2.1.1/780b16dbc779dfb1f6e89e4c67517c2d45b20dc3",
-      "integrity": "sha512-uV7vtWdFPTfSmNXIUqGWZx7pqO10T7Hel5EYR0bHlo4MjYT/+K0UTmwqzuQJnz7/aTI9HHVakHKZwCG+Kz0NYw==",
+      "version": "1.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@swisstopo/swissgeol-ui-core/1.0.0/7763fd784325906c8016c119eebe4b0f0a75bf98",
+      "integrity": "sha512-452W39HCtFR9P/ebA4vDTb+o0P/31WLcCVTFHj/tMwa+ypklYhDaGfsinonWo3gIvIAD0DBksrCHN9CIZijOSA==",
       "license": "MIT"
     },
     "node_modules/@trevoreyre/autocomplete-js": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -33,7 +33,7 @@
     "@geoblocks/ga-search": "0.0.22",
     "@lit/context": "^1.1.3",
     "@lit/task": "^1.0.1",
-    "@swisstopo/swissgeol-ui-core": "^2.1.1",
+    "@swisstopo/swissgeol-ui-core": "^1.0.0",
     "cesium": "1.123.1",
     "d3-array": "3.2.4",
     "d3-axis": "3.0.0",

--- a/ui/src/elements/ngm-voxel-filter.ts
+++ b/ui/src/elements/ngm-voxel-filter.ts
@@ -24,7 +24,7 @@ export class NgmVoxelFilter extends LitElementI18n {
   @query('.max-conductivity')
   accessor maxConductivityInput!: HTMLInputElement;
   @query('.vox_filter_include_undefined')
-  accessor includeUndefinedConductivity!: HTMLInputElement;
+  accessor includeUndefinedConductivity: HTMLInputElement | null = null;
   @queryAll('.lithology-checkbox input[type="checkbox"]')
   accessor lithologyCheckbox!: NodeListOf<HTMLInputElement>;
 
@@ -88,7 +88,7 @@ export class NgmVoxelFilter extends LitElementI18n {
     shader.setUniform('u_filter_operator', value);
     shader.setUniform(
       'u_filter_include_undefined_conductivity',
-      this.includeUndefinedConductivity.checked,
+      this.includeUndefinedConductivity?.checked ?? true,
     );
 
     this.viewer.scene.requestRender();
@@ -115,7 +115,9 @@ export class NgmVoxelFilter extends LitElementI18n {
     this.querySelectorAll<HTMLFormElement>('.content-container form').forEach(
       (form) => form.reset(),
     );
-    this.includeUndefinedConductivity.checked = true;
+    if (this.includeUndefinedConductivity) {
+      this.includeUndefinedConductivity.checked = true;
+    }
   }
 
   firstUpdated() {


### PR DESCRIPTION
Fixes bug where filter could not be opened again after closing for rheintal because of null value for input checkbox