### PR TITLE
Disable target point tool

### DIFF
--- a/ui/src/elements/ngm-nav-tools.ts
+++ b/ui/src/elements/ngm-nav-tools.ts
@@ -440,17 +440,21 @@ export class NgmNavTools extends LitElementI18n {
           })}"
           @click=${() => this.dispatchEvent(new CustomEvent('togglecamconfig'))}
         ></div>
-        <div
-          title="${i18next.t('nav_target_point')}"
-          class="ngm-coords-icon ${classMap({
-            'ngm-active-icon': this.showTargetPoint,
-            'ngm-disabled':
-              this.lockType !== '' && this.lockType !== 'elevation',
-          })}"
-          @click=${() => this.toggleReference()}
-        ></div>
       </div>
       ${dragArea}
     `;
   }
+
+  // TODO Fix the target point tool and then add this icon back to the toolbar.
+  /*
+  <div
+    title="${i18next.t('nav_target_point')}"
+    class="ngm-coords-icon ${classMap({
+      'ngm-active-icon': this.showTargetPoint,
+      'ngm-disabled':
+        this.lockType !== '' && this.lockType !== 'elevation',
+    })}"
+    @click=${() => this.toggleReference()}
+  ></div>
+   */
 }


### PR DESCRIPTION
The target point anchor is currently not working - the camera doesn't rotate around it, so it is essentially useless. As discussed with @nOester, we remove the tool from the UI and will attempt a full bugfix for the next release.