### PR TITLE
Split deployment host into ui and api

### DIFF
--- a/k8s/templates/ingress-route.yaml
+++ b/k8s/templates/ingress-route.yaml
@@ -8,13 +8,13 @@ spec:
     - web
   routes:
     - kind: Rule
-      match: Host(`{{ .Values.host }}`)
+      match: Host(`{{ .Values.ui.host }}`)
       priority: 100
       services:
         - name: {{ .Release.Name }}-ui
           port: 80
     - kind: Rule
-      match: Host(`api.{{ .Values.host }}`) && PathPrefix(`/api`)
+      match: Host(`api.{{ .Values.api.host }}`) && PathPrefix(`/api`)
       priority: 120
       services:
         - name: {{ .Release.Name }}-api

--- a/k8s/values.template.yaml
+++ b/k8s/values.template.yaml
@@ -1,5 +1,10 @@
 env:
-host:
+
+ui:
+  host:
+
+api:
+  host:
 
 docker:
   api_image:


### PR DESCRIPTION
The PROD Deployment uses a different host pattern than DEV and INT, which requires us to be able to provide fully separate hosts for the UI and API endpoints.

After merging this, the deployment configurations in the Vault also need to be adjusted according to the template. Be aware that currently, PROD is running with a manually modified version of `ingress-route.yml`, so as soon as this hits `develop`, we should redeploy all environments.