### PR TITLE
Feature 1465: Integration swissBEDROCK.

### DIFF
--- a/k8s/templates/ingress-route.yaml
+++ b/k8s/templates/ingress-route.yaml
@@ -20,8 +20,11 @@ spec:
         - name: {{ .Release.Name }}-api
           port: 3000
     - kind: Rule
-      match: Host(`{{ .Values.api.host }}`) && PathPrefixStrip(`/titiler`)
+      match: Host(`{{ .Values.api.host }}`) && PathPrefix(`/titiler`)
       priority: 140
+      middlewares:
+        - name: {{ .Release.Name }}-titiler-middleware
+          namespace: {{ .Release.Namespace }}
       services:
         - name: {{ .Release.Name }}-titiler
           port: 8000

--- a/k8s/templates/middleware.titiler.yaml
+++ b/k8s/templates/middleware.titiler.yaml
@@ -1,0 +1,9 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ .Release.Name }}-titiler-middleware
+  namespace: {{ .Release.Namespace }}
+spec:
+  stripPrefix:
+    prefixes:
+      - /titiler


### PR DESCRIPTION
Resolves #1465.

Fixes the routing of the new `titiler` service in k8s.