### PR TITLE
Feature 1630: Icon von 2D/3D-Modus ändern

### DIFF
--- a/ui/cypress/e2e/controls/control-2d.feature
+++ b/ui/cypress/e2e/controls/control-2d.feature
@@ -8,12 +8,12 @@ Feature: Use 2D Control
     Scenario: Switch to 2D mode
       When the user clicks on the 2d control
       Then the map is in 2d mode
-      And the 2d control shows the 2d icon
+      And the 2d control shows the 3d icon
 
     Scenario: Switch back to 3D mode
       When the user clicks on the 2d control
       And the user clicks on the 2d control
       Then the map is in 3d mode
-      And the 2d control shows the 3d icon
+      And the 2d control shows the 2d icon
 
 

--- a/ui/src/features/controls/controls-2d-action.element.ts
+++ b/ui/src/features/controls/controls-2d-action.element.ts
@@ -35,7 +35,7 @@ export class Controls2dAction extends CoreElement {
   };
 
   readonly render = () =>
-    html`<ngm-core-icon icon="${this.isActive ? '2d' : '3d'}"></ngm-core-icon>`;
+    html`<ngm-core-icon icon="${this.isActive ? '3d' : '2d'}"></ngm-core-icon>`;
 
   static readonly styles = css`
     :host {

--- a/ui/src/features/controls/controls/control2d.controller.ts
+++ b/ui/src/features/controls/controls/control2d.controller.ts
@@ -115,7 +115,7 @@ export class Control2dController {
 
   private disableTiltGestures(): void {
     this.tiltEventTypesBackup = this.cameraController.tiltEventTypes;
-    this.lookEventTypesBackup = this.cameraController.tiltEventTypes;
+    this.lookEventTypesBackup = this.cameraController.lookEventTypes;
     this.cameraController.tiltEventTypes = [];
     this.cameraController.lookEventTypes = [];
   }


### PR DESCRIPTION
Resolves #1630.

- Switches the 3d and 2d icon.
- Fixes an issue where camera tilting was no longer working correctly after toggling into 2d and back.