### PR TITLE
Feature 1648: swissBEDROCK - Korrektur und Ergänzung Farbskala

### DIFF
--- a/ui/src/features/layer/display/layer-display-list-item.element.ts
+++ b/ui/src/features/layer/display/layer-display-list-item.element.ts
@@ -10,6 +10,7 @@ import { Entity, Viewer } from 'cesium';
 import i18next from 'i18next';
 import { LayerService } from 'src/features/layer/layer.service';
 import { consume } from '@lit/context';
+import { LayerTiffController } from 'src/features/layer';
 
 @customElement('ngm-layer-display-list-item')
 export class LayerDisplayListItem extends CoreElement {
@@ -113,6 +114,10 @@ export class LayerDisplayListItem extends CoreElement {
       return;
     }
     const entity = await this.layer.promise;
+    if (entity instanceof LayerTiffController) {
+      entity.zoomIntoView();
+      return;
+    }
     await this.viewer.flyTo(entity as unknown as Entity);
   }
 

--- a/ui/src/features/layer/info/layer-info.service.ts
+++ b/ui/src/features/layer/info/layer-info.service.ts
@@ -27,7 +27,7 @@ import {
   LayerInfoSource,
 } from 'src/features/layer/info/layer-info.model';
 import { isSameLayer, LayerService } from 'src/features/layer/layer.service';
-import { LayerTreeNode } from 'src/layertree';
+import { LayerTreeNode, LayerType } from 'src/layertree';
 import { LayerInfoPickerForGeoadmin } from 'src/features/layer/info/pickers/layer-info-picker-for-geoadmin';
 
 export class LayerInfoService extends BaseService {
@@ -206,6 +206,9 @@ export class LayerInfoService extends BaseService {
   private readonly handleQueryableLayerAddition = (
     layer: LayerTreeNode,
   ): void => {
+    if (layer.type === LayerType.geoTIFF) {
+      return;
+    }
     this.queueModification({
       source: layer,
       action: () =>

--- a/ui/src/layertree.ts
+++ b/ui/src/layertree.ts
@@ -80,16 +80,6 @@ export interface GeoTIFFLayer {
    */
   metadata: {
     /**
-     * The TIFF's internal coordinate system.
-     */
-    crs: string;
-
-    /**
-     * The TIFF's transform matrix.
-     */
-    transform: [[number, number, number], [number, number, number]];
-
-    /**
      * The width and height of each of the TIFF's cells, in meters.
      */
     cellSize: number;
@@ -1350,11 +1340,6 @@ const group_01: LayerTreeNode =
                   },
                 ],
                 metadata: {
-                  crs: 'EPSG:3857',
-                  transform: [
-                    [14.58, 0.0, 657114.8],
-                    [0.0, -14.63, 6079036.3],
-                  ],
                   cellSize: 10,
                 },
               } satisfies GeoTIFFLayer,


### PR DESCRIPTION
Resolves #1648.

Fixes an issue where rounding of the geoTIFF metadata resulted in highlights not being calculated correctly. This has now been fixed by dynamically loading and calculating the metadata via TiTiler.