### PR TITLE
TO_TRANSLATED translated

### DIFF
--- a/ui/locales/app/app.it.json
+++ b/ui/locales/app/app.it.json
@@ -82,7 +82,7 @@
   "dtd_ion_token_label": "Cesium Ion Token",
   "dtd_lakes_rivers_map_label": "Laghi e fiumi",
   "dtd_legend": "Leggenda",
-  "dtd_documentation": "TO_BE_TRANSLATED",
+  "dtd_documentation": "Documentazione",
   "dtd_load_ion_assets_btn": "Carica l'elenco dei set di dati",
   "dtd_max_size_exceeded_warn": "La dimensione massima del file è ",
   "dtd_no_file_to_upload_warn": "Nessun file da scaricare",


### PR DESCRIPTION
Es gab noch ein "To_BE_TRANSLATED". das ist nun übersetzt.
Danke für dein Review