### PR TITLE
Bugfix 1656: swissBEDROCK | Bandwechsler blockiert

### DIFF
--- a/ui/src/features/layer/tiff/layer-tiff.controller.ts
+++ b/ui/src/features/layer/tiff/layer-tiff.controller.ts
@@ -60,7 +60,9 @@ export class LayerTiffController {
     if (this.active != null) {
       oldImageryIndex =
         this.viewer.scene.imageryLayers.indexOf(this.active.imagery) ?? -1;
-      this.viewer.scene.imageryLayers.remove(this.active.imagery, false);
+      if (oldImageryIndex >= 0) {
+        this.viewer.scene.imageryLayers.remove(this.active.imagery, false);
+      }
     }
 
     const imagery = this.makeImagery(band);


### PR DESCRIPTION
Resolves #1656.

Thanks to @nOester local stack trace, I _think_ I got the error.

What I'm assuming is happening:
1. The tiff's band is switched.
2. This removes the active and adds a new one.
3. Before the new one is fully added, the band is switched again.
4. This causes the already removed band to be removed again, triggering an error.

The fix is now to not remove the band imagery if it cannot be found in the active imagery list, which is a check we have to do anyways.