### PR TITLE
Bugfix 1659: Zeichnen auf Objekten

### DIFF
--- a/ui/src/toolbox/GeometryController.ts
+++ b/ui/src/toolbox/GeometryController.ts
@@ -658,7 +658,7 @@ export class GeometryController {
         entityAttrs.polyline = {
           show: true,
           positions: attributes.positions,
-          clampToGround: false,
+          clampToGround: true,
           width: 4,
           material: color
             ? new Color(color.red, color.green, color.blue, GEOMETRY_LINE_ALPHA)


### PR DESCRIPTION
Resolves #1659.

Allows line drawings to once again clamp to the ground.