### PR TITLE
feat(ui): seismic 3D image-slice planes

### DIFF
--- a/ui/locales/catalog/catalog.de.json
+++ b/ui/locales/catalog/catalog.de.json
@@ -11,6 +11,7 @@
     "legend": "Legende",
     "download": "Herunterladen / Legende",
     "filter": "Filter öffnen",
+    "slice": "Schnitte",
     "time_travel": "Zeitreise",
     "remove": "Entfernen"
   },
@@ -56,6 +57,27 @@
     "title": "{{ layer }} - Bänder",
     "open": "Bänder anzeigen",
     "legend": "Legende"
+  },
+  "slice_window": {
+    "title": "{{ layer }} - Schnitte",
+    "mode": {
+      "label": "Modus",
+      "single": "Einzelner Schnitt",
+      "multiple": "Mehrere Schnitte",
+      "coming_soon": "demnächst verfügbar"
+    },
+    "crossline": "Crossline",
+    "inline": "Inline",
+    "depth": "Depth",
+    "amount": "Anzahl Schnitte",
+    "warning_large": "Dies ist ein grosser Datensatz. Wir empfehlen, die Anzahl Schnitte für {{axis}} auf {{max}} zu begrenzen.",
+    "legend": {
+      "relative_amplitude": "Relative Amplitude"
+    },
+    "preload": {
+      "loading": "Schnitte werden vorgeladen… {{loaded}}/{{total}}",
+      "done": "Schnitte im Cache ({{total}})"
+    }
   },
   "layers_unavailable": "Einige Layer sind nicht verfügbar ({{sources}}). {{count}} Layer wurden im Katalog ausgeblendet."
 }

--- a/ui/locales/catalog/catalog.en.json
+++ b/ui/locales/catalog/catalog.en.json
@@ -11,6 +11,7 @@
     "legend": "Legend",
     "download": "Download / Legend",
     "filter": "Open Filter",
+    "slice": "Slices",
     "time_travel": "Journey through time",
     "remove": "Remove"
   },
@@ -56,6 +57,27 @@
     "title": "{{ layer }} - Bands",
     "open": "Show bands",
     "legend": "Legend"
+  },
+  "slice_window": {
+    "title": "{{ layer }} - Slices",
+    "mode": {
+      "label": "Mode",
+      "single": "Single Slice",
+      "multiple": "Multiple Slices",
+      "coming_soon": "coming soon"
+    },
+    "crossline": "Crossline",
+    "inline": "Inline",
+    "depth": "Depth",
+    "amount": "Amount of Slices",
+    "warning_large": "This is a large dataset. We recommend limiting the amount of slices for {{axis}} to {{max}}.",
+    "legend": {
+      "relative_amplitude": "Relative Amplitude"
+    },
+    "preload": {
+      "loading": "Preloading slices… {{loaded}}/{{total}}",
+      "done": "Slices cached ({{total}})"
+    }
   },
   "layers_unavailable": "Some layers are unavailable ({{sources}}). {{count}} layers were hidden from the catalog."
 }

--- a/ui/locales/catalog/catalog.fr.json
+++ b/ui/locales/catalog/catalog.fr.json
@@ -11,6 +11,7 @@
     "legend": "Légende",
     "download": "Télécharger / Légende",
     "filter": "Ouvrir le filtre",
+    "slice": "Coupes",
     "time_travel": "Voyage dans le temps",
     "remove": "Enlever"
   },
@@ -56,6 +57,27 @@
     "title": "{{ layer }} - Bandes",
     "open": "Afficher les bandes",
     "legend": "Légende"
+  },
+  "slice_window": {
+    "title": "{{ layer }} - Coupes",
+    "mode": {
+      "label": "Mode",
+      "single": "Coupe unique",
+      "multiple": "Coupes multiples",
+      "coming_soon": "bientôt disponible"
+    },
+    "crossline": "Crossline",
+    "inline": "Inline",
+    "depth": "Depth",
+    "amount": "Nombre de coupes",
+    "warning_large": "Il s'agit d'un grand jeu de données. Nous recommandons de limiter le nombre de coupes pour {{axis}} à {{max}}.",
+    "legend": {
+      "relative_amplitude": "Amplitude relative"
+    },
+    "preload": {
+      "loading": "Préchargement des coupes… {{loaded}}/{{total}}",
+      "done": "Coupes en cache ({{total}})"
+    }
   },
   "layers_unavailable": "Certaines couches ne sont pas disponibles ({{sources}}). {{count}} couches ont été masquées du catalogue."
 }

--- a/ui/locales/catalog/catalog.it.json
+++ b/ui/locales/catalog/catalog.it.json
@@ -11,6 +11,7 @@
     "legend": "Leggenda",
     "download": "Scaricare / Scala",
     "filter": "Aprire il filtro",
+    "slice": "Sezioni",
     "time_travel": "Viaggio nel tempo",
     "remove": "Rimuovere"
   },
@@ -56,6 +57,27 @@
     "title": "{{ layer }} - Bande",
     "open": "Visualizzare le bande",
     "legend": "Legenda"
+  },
+  "slice_window": {
+    "title": "{{ layer }} - Sezioni",
+    "mode": {
+      "label": "Modalità",
+      "single": "Sezione singola",
+      "multiple": "Sezioni multiple",
+      "coming_soon": "prossimamente"
+    },
+    "crossline": "Crossline",
+    "inline": "Inline",
+    "depth": "Depth",
+    "amount": "Numero di sezioni",
+    "warning_large": "Questo è un set di dati di grandi dimensioni. Consigliamo di limitare il numero di sezioni per {{axis}} a {{max}}.",
+    "legend": {
+      "relative_amplitude": "Ampiezza relativa"
+    },
+    "preload": {
+      "loading": "Precaricamento sezioni… {{loaded}}/{{total}}",
+      "done": "Sezioni in cache ({{total}})"
+    }
   },
   "layers_unavailable": "Alcuni layer non sono disponibili ({{sources}}). {{count}} layer sono stati nascosti dal catalogo."
 }

--- a/ui/src/elements/ngm-ion-modal.ts
+++ b/ui/src/elements/ngm-ion-modal.ts
@@ -202,6 +202,7 @@ export class NgmIonModal extends CoreElement {
           infoBox: null,
           orderOfProperties: [],
           isPartiallyTransparent: false,
+          sliceSelection: null,
           customProperties: {},
         } satisfies Tiles3dLayer;
         break;

--- a/ui/src/features/catalog/catalog.module.ts
+++ b/ui/src/features/catalog/catalog.module.ts
@@ -5,6 +5,7 @@ import './display/details/catalog-display-times-detail.element';
 import './display/details/catalog-display-tiff-bands.element';
 import './display/details/catalog-display-tiff-legend.element';
 import './display/details/catalog-display-voxel-filter-detail.element';
+import './display/details/catalog-display-slice-detail.element';
 
 import './tree/catalog-tree.element';
 import './tree/catalog-tree-group.element';

--- a/ui/src/features/catalog/display/catalog-display-list-item.element.ts
+++ b/ui/src/features/catalog/display/catalog-display-list-item.element.ts
@@ -12,6 +12,7 @@ import {
   AnyLayer,
   getLayerLabel,
   isBackgroundLayer,
+  isDefaultSliceSelection,
   Layer,
   LayerType,
   Tiles3dLayerController,
@@ -69,20 +70,32 @@ export class CatalogDisplayListItem extends CoreElement {
       return;
     }
 
-    if (controller instanceof Tiles3dLayerController) {
-      this.canZoom = !!controller.tileset?.boundingSphere;
-      if (!this.canZoom) {
-        const checkInterval = setInterval(() => {
-          if (controller.tileset?.boundingSphere) {
-            this.canZoom = true;
-            this.requestUpdate();
-            clearInterval(checkInterval);
-          }
-        }, 100);
-      }
-    } else {
+    if (!(controller instanceof Tiles3dLayerController)) {
       this.canZoom = true;
+      return;
     }
+
+    this.canZoom = !!controller.tileset?.boundingSphere;
+    if (this.canZoom) {
+      return;
+    }
+
+    // Tileset and slice metadata finish loading asynchronously after activation.
+    const startedAt = Date.now();
+    const checkInterval = setInterval(() => {
+      const isReady = !!controller.tileset?.boundingSphere;
+      if (isReady) {
+        this.canZoom = true;
+      }
+      if (
+        controller.supportsSliceSelection ||
+        (isReady && Date.now() - startedAt > 2_000) ||
+        Date.now() - startedAt > 15_000
+      ) {
+        this.requestUpdate();
+        clearInterval(checkInterval);
+      }
+    }, 100);
   }
 
   updated() {
@@ -136,8 +149,10 @@ export class CatalogDisplayListItem extends CoreElement {
       ...options,
       onClose: () => {
         this.windows[name] = null;
+        this.requestUpdate();
       },
     });
+    this.requestUpdate();
   }
 
   private readonly openLegend = (): void =>
@@ -183,6 +198,47 @@ export class CatalogDisplayListItem extends CoreElement {
       `,
     });
 
+  private readonly openSlice = (): void =>
+    this.openWindow('slice', {
+      title: () =>
+        i18next.t('catalog:slice_window.title', {
+          layer: getLayerLabel(this.layer),
+        }),
+      body: () => html`
+        <ngm-catalog-display-slice-detail
+          .layerId=${this.layer.id}
+        ></ngm-catalog-display-slice-detail>
+      `,
+    });
+
+  private get tiles3dController(): Tiles3dLayerController | null {
+    if (this.layer.type !== LayerType.Tiles3d) {
+      return null;
+    }
+    const controller = this.layerService.controller(this.layer.id);
+    return controller instanceof Tiles3dLayerController ? controller : null;
+  }
+
+  private get supportsSliceSelection(): boolean {
+    return this.tiles3dController?.supportsSliceSelection === true;
+  }
+
+  private get isSliceFilterActive(): boolean {
+    if (!this.supportsSliceSelection) {
+      return false;
+    }
+    if (this.windows.slice !== null) {
+      return true;
+    }
+    const selection =
+      this.layer.type === LayerType.Tiles3d ? this.layer.sliceSelection : null;
+    const defaults = this.tiles3dController?.getDefaultSliceSelection() ?? null;
+    if (selection === null || defaults === null) {
+      return false;
+    }
+    return !isDefaultSliceSelection(selection, defaults);
+  }
+
   private readonly handleOpacityChangeEvent = throttle(
     (event: SliderChangeEvent): void => {
       this.layerService.update(this.layerId, { opacity: event.detail.value });
@@ -212,7 +268,6 @@ export class CatalogDisplayListItem extends CoreElement {
         </ngm-core-button>
 
         <span class="title">${title}</span>
-
         <div class="suffix">
           ${when(
             isBackgroundLayer(this.layer),
@@ -241,6 +296,23 @@ export class CatalogDisplayListItem extends CoreElement {
             ${Math.round(this.layer.opacity * 100)}%
           </ngm-core-button>
           ${tooltip(i18next.t('catalog:display.opacity'))}
+          ${when(
+            this.supportsSliceSelection,
+            () => html`
+              <ngm-core-button
+                transparent
+                variant="tertiary"
+                shape="icon"
+                class="slice-filter"
+                ?active="${this.isSliceFilterActive}"
+                data-cy="slice-filter"
+                @click="${this.openSlice}"
+              >
+                <ngm-core-icon icon="filter"></ngm-core-icon>
+              </ngm-core-button>
+              ${tooltip(i18next.t('catalog:display.slice'))}
+            `,
+          )}
           ${when(!isBackgroundLayer(this.layer), this.renderActions)}
         </div>
       </div>
@@ -317,6 +389,15 @@ export class CatalogDisplayListItem extends CoreElement {
           >
             <ngm-core-icon icon="filter"></ngm-core-icon>
             ${i18next.t('catalog:display.filter')}
+          </ngm-core-dropdown-item>
+        `,
+      )}
+      ${when(
+        this.supportsSliceSelection,
+        () => html`
+          <ngm-core-dropdown-item role="button" @click="${this.openSlice}">
+            <ngm-core-icon icon="filter"></ngm-core-icon>
+            ${i18next.t('catalog:display.slice')}
           </ngm-core-dropdown-item>
         `,
       )}
@@ -536,7 +617,7 @@ export class CatalogDisplayListItem extends CoreElement {
   `;
 }
 
-type WindowName = 'legend' | 'times' | 'voxelFilter' | 'tiffFilter';
+type WindowName = 'legend' | 'times' | 'voxelFilter' | 'tiffFilter' | 'slice';
 
 type WindowMapping = Record<WindowName, CoreWindow | null>;
 
@@ -560,6 +641,7 @@ const getWindowsOfLayer = (layerId: Id<AnyLayer>): WindowMapping => {
     tiffFilter: null,
     times: null,
     voxelFilter: null,
+    slice: null,
   };
   windowMappingsByLayerId.set(layerId, newMapping);
   return newMapping;

--- a/ui/src/features/catalog/display/catalog-display-list-item.element.ts
+++ b/ui/src/features/catalog/display/catalog-display-list-item.element.ts
@@ -48,6 +48,7 @@ export class CatalogDisplayListItem extends CoreElement {
   accessor canZoom = true;
 
   private windows!: WindowMapping;
+  private canZoomPollIntervalId: ReturnType<typeof setInterval> | null = null;
 
   connectedCallback() {
     super.connectedCallback();
@@ -63,7 +64,21 @@ export class CatalogDisplayListItem extends CoreElement {
     );
   }
 
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.stopCanZoomPolling();
+  }
+
+  private stopCanZoomPolling(): void {
+    if (this.canZoomPollIntervalId !== null) {
+      clearInterval(this.canZoomPollIntervalId);
+      this.canZoomPollIntervalId = null;
+    }
+  }
+
   private updateCanZoom(): void {
+    this.stopCanZoomPolling();
+
     const controller = this.layerService.controller(this.layerId);
     if (!controller) {
       this.canZoom = false;
@@ -80,19 +95,25 @@ export class CatalogDisplayListItem extends CoreElement {
       return;
     }
 
-    // Tileset and slice metadata finish loading asynchronously after activation.
-    const startedAt = Date.now();
-    const checkInterval = setInterval(() => {
+    // Tileset and slice metadata finish loading asynchronously after
+    // activation. Poll until readiness is actually observed rather than
+    // giving up after a fixed timeout — otherwise a tileset that becomes
+    // ready after the timeout would leave the zoom button permanently
+    // disabled. Polling is stopped as soon as it succeeds, the layer/
+    // controller changes (see `updateCanZoom` call above), or the element
+    // disconnects (see `disconnectedCallback`).
+    this.canZoomPollIntervalId = setInterval(() => {
+      if (this.layerService.controller(this.layerId) !== controller) {
+        // Controller was swapped out (e.g. layer deactivated/reactivated) —
+        // the subscription above will have already called `updateCanZoom()`
+        // for the new controller, so just stop this stale poll.
+        this.stopCanZoomPolling();
+        return;
+      }
       const isReady = !!controller.tileset?.boundingSphere;
       if (isReady) {
         this.canZoom = true;
-      }
-      if (
-        (isReady && Date.now() - startedAt > 2_000) ||
-        Date.now() - startedAt > 15_000
-      ) {
-        this.requestUpdate();
-        clearInterval(checkInterval);
+        this.stopCanZoomPolling();
       }
     }, 100);
   }

--- a/ui/src/features/catalog/display/catalog-display-list-item.element.ts
+++ b/ui/src/features/catalog/display/catalog-display-list-item.element.ts
@@ -88,7 +88,6 @@ export class CatalogDisplayListItem extends CoreElement {
         this.canZoom = true;
       }
       if (
-        controller.supportsSliceSelection ||
         (isReady && Date.now() - startedAt > 2_000) ||
         Date.now() - startedAt > 15_000
       ) {

--- a/ui/src/features/catalog/display/details/catalog-display-slice-detail.element.ts
+++ b/ui/src/features/catalog/display/details/catalog-display-slice-detail.element.ts
@@ -389,7 +389,7 @@ export class CatalogDisplaySliceDetail extends CoreElement {
           return null;
         }
         const min = numbers[0];
-        const max = numbers[numbers.length - 1];
+        const max = numbers.at(-1)!;
         const value = this.getSingleValue(axis);
         return html`
           <div class="axis">

--- a/ui/src/features/catalog/display/details/catalog-display-slice-detail.element.ts
+++ b/ui/src/features/catalog/display/details/catalog-display-slice-detail.element.ts
@@ -126,12 +126,22 @@ export class CatalogDisplaySliceDetail extends CoreElement {
   }
 
   disconnectedCallback(): void {
+    clearTimeout(this.preloadBannerHideTimer);
+    // Commit any pending slider value *before* tearing down HUD preloading
+    // state below. `commitDraftSingle()` may call `layerService.update()`,
+    // which emits synchronously (`BehaviorSubject.next()`), re-entrantly
+    // re-running the `layer$` subscription from `connectedCallback()` — its
+    // teardown (via `super.disconnectedCallback()`) has not run yet at this
+    // point. Committing first means that reentrant run still sees
+    // `hudActiveController`/`preloadSubscriptionAxis` pointing at the same
+    // controller, so it is a no-op instead of turning HUD preloading back on.
+    this.cancelScheduledCommit();
+    this.commitDraftSingle();
+
     this.hudActiveController?.setHudActive(false);
     this.hudActiveController = null;
     this.preloadSubscriptionAxis = null;
-    clearTimeout(this.preloadBannerHideTimer);
-    this.cancelScheduledCommit();
-    this.commitDraftSingle();
+
     super.disconnectedCallback();
   }
 

--- a/ui/src/features/catalog/display/details/catalog-display-slice-detail.element.ts
+++ b/ui/src/features/catalog/display/details/catalog-display-slice-detail.element.ts
@@ -23,6 +23,40 @@ import { when } from 'lit/directives/when.js';
 /** How long the preload banner stays visible after finishing, before fading out. */
 const PRELOAD_BANNER_LINGER_MS = 3_000;
 
+/**
+ * Slice numbers are not guaranteed to be contiguous (e.g. `[10, 20, 30]`), so
+ * a plain min/max range with a step of 1 would let the slider/stepper select
+ * values that do not actually exist. Snap to the closest value that is
+ * actually present instead. Assumes `numbers` is sorted ascending and
+ * non-empty.
+ */
+const nearestSliceNumber = (
+  numbers: readonly number[],
+  value: number,
+): number =>
+  numbers.reduce((closest, candidate) =>
+    Math.abs(candidate - value) < Math.abs(closest - value)
+      ? candidate
+      : closest,
+  );
+
+/**
+ * Index of the closest entry in `numbers` to `value`, offset by `step`
+ * (`-1`/`+1`), clamped to the array bounds. Used to move the stepper to the
+ * previous/next *existing* slice number rather than blindly adding/subtracting
+ * 1, which could land on a number that is not actually present.
+ */
+const stepSliceNumber = (
+  numbers: readonly number[],
+  value: number,
+  step: -1 | 1,
+): number => {
+  const nearest = nearestSliceNumber(numbers, value);
+  const index = numbers.indexOf(nearest);
+  const nextIndex = Math.min(numbers.length - 1, Math.max(0, index + step));
+  return numbers[nextIndex];
+};
+
 @customElement('ngm-catalog-display-slice-detail')
 export class CatalogDisplaySliceDetail extends CoreElement {
   @property()
@@ -209,12 +243,15 @@ export class CatalogDisplaySliceDetail extends CoreElement {
     if (current === null) {
       return;
     }
+    const numbers = this.controller?.getAxisNumbers(axis) ?? [];
+    const snapped =
+      numbers.length > 0 ? nearestSliceNumber(numbers, value) : value;
     const nextSingle = {
       ...(this.draftSingle ?? current.single),
-      [axis]: value,
+      [axis]: snapped,
     };
     this.draftSingle = nextSingle;
-    this.controller?.prioritizeAxisNeighborhood(axis, value);
+    this.controller?.prioritizeAxisNeighborhood(axis, snapped);
     this.updateSelection({ single: nextSingle });
   };
 
@@ -227,7 +264,9 @@ export class CatalogDisplaySliceDetail extends CoreElement {
       return;
     }
     this.isSliderDragging = true;
-    const value = Math.round(event.detail.value);
+    const numbers = this.controller?.getAxisNumbers(axis) ?? [];
+    const raw = Math.round(event.detail.value);
+    const value = numbers.length > 0 ? nearestSliceNumber(numbers, raw) : raw;
     this.draftSingle = {
       ...(this.draftSingle ?? current.single),
       [axis]: value,
@@ -397,8 +436,12 @@ export class CatalogDisplaySliceDetail extends CoreElement {
               <span class="axis-label">
                 ${i18next.t(`catalog:slice_window.${axis}`)}
               </span>
-              ${this.renderStepper(value, min, max, (next) =>
-                this.setSingleSlice(axis, next),
+              ${this.renderStepper(
+                value,
+                min,
+                max,
+                (next) => this.setSingleSlice(axis, next),
+                numbers,
               )}
             </div>
             <ngm-core-slider
@@ -468,13 +511,24 @@ export class CatalogDisplaySliceDetail extends CoreElement {
     min: number,
     max: number,
     onChange: (value: number) => void,
+    /**
+     * The actual selectable values, when they may be non-contiguous (e.g.
+     * seismic slice numbers). When provided, stepping/typing snaps to the
+     * closest existing value instead of a blind +/-1.
+     */
+    numbers?: readonly number[],
   ) => html`
     <div class="stepper">
       <button
         type="button"
         class="stepper-btn"
         ?disabled=${value <= min}
-        @click=${() => onChange(value - 1)}
+        @click=${() =>
+          onChange(
+            numbers !== undefined
+              ? stepSliceNumber(numbers, value, -1)
+              : value - 1,
+          )}
       >
         &lt;
       </button>
@@ -489,14 +543,24 @@ export class CatalogDisplaySliceDetail extends CoreElement {
           if (Number.isNaN(raw)) {
             return;
           }
-          onChange(Math.max(min, Math.min(max, Math.round(raw))));
+          const clamped = Math.max(min, Math.min(max, Math.round(raw)));
+          onChange(
+            numbers !== undefined
+              ? nearestSliceNumber(numbers, clamped)
+              : clamped,
+          );
         }}
       />
       <button
         type="button"
         class="stepper-btn"
         ?disabled=${value >= max}
-        @click=${() => onChange(value + 1)}
+        @click=${() =>
+          onChange(
+            numbers !== undefined
+              ? stepSliceNumber(numbers, value, 1)
+              : value + 1,
+          )}
       >
         &gt;
       </button>

--- a/ui/src/features/catalog/display/details/catalog-display-slice-detail.element.ts
+++ b/ui/src/features/catalog/display/details/catalog-display-slice-detail.element.ts
@@ -94,6 +94,7 @@ export class CatalogDisplaySliceDetail extends CoreElement {
   disconnectedCallback(): void {
     this.hudActiveController?.setHudActive(false);
     this.hudActiveController = null;
+    this.preloadSubscriptionAxis = null;
     clearTimeout(this.preloadBannerHideTimer);
     this.cancelScheduledCommit();
     this.commitDraftSingle();
@@ -405,6 +406,7 @@ export class CatalogDisplaySliceDetail extends CoreElement {
               .min=${min}
               .max=${max}
               .step=${1}
+              .label=${i18next.t(`catalog:slice_window.${axis}`)}
               @change=${(e: SliderChangeEvent) => this.onSliderInput(axis, e)}
               @done=${this.onSliderDone}
             ></ngm-core-slider>

--- a/ui/src/features/catalog/display/details/catalog-display-slice-detail.element.ts
+++ b/ui/src/features/catalog/display/details/catalog-display-slice-detail.element.ts
@@ -1,0 +1,754 @@
+import { css, html } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { CoreElement } from 'src/features/core';
+import {
+  RECOMMENDED_MAX_SLICES_BY_AXIS,
+  SEISMIC_SLICE_AXES,
+  SeismicSliceAxis,
+  SlicePreloadProgress,
+  SliceViewMode,
+  Tiles3dLayer,
+  Tiles3dLayerController,
+  Tiles3dSliceSelection,
+  emptySlicePreloadProgress,
+} from 'src/features/layer';
+import { consume } from '@lit/context';
+import { LayerService } from 'src/features/layer/layer.service';
+import { Id } from 'src/models/id.model';
+import { SliderChangeEvent } from 'src/features/core/core-slider.element';
+import { applyTypography } from 'src/styles/theme';
+import i18next from 'i18next';
+import { when } from 'lit/directives/when.js';
+
+/** How long the preload banner stays visible after finishing, before fading out. */
+const PRELOAD_BANNER_LINGER_MS = 3_000;
+
+@customElement('ngm-catalog-display-slice-detail')
+export class CatalogDisplaySliceDetail extends CoreElement {
+  @property()
+  accessor layerId!: Id<Tiles3dLayer>;
+
+  @state()
+  accessor layer!: Tiles3dLayer;
+
+  @state()
+  accessor controller: Tiles3dLayerController | null = null;
+
+  /** Local single-mode values so the slider UI stays snappy while Cesium lags. */
+  @state()
+  accessor draftSingle: Record<SeismicSliceAxis, number> | null = null;
+
+  @state()
+  accessor preloadProgress: SlicePreloadProgress = emptySlicePreloadProgress();
+
+  /**
+   * Whether the preload banner should currently be rendered. Kept separate
+   * from `preloadProgress` itself: we only ever show the banner while slices
+   * are actually being fetched, never for a "done" state we didn't personally
+   * observe the loading part of (e.g. everything was already cached before
+   * the panel opened), and we keep it visible briefly after finishing rather
+   * than snapping away instantly.
+   */
+  @state()
+  accessor isPreloadBannerVisible = false;
+
+  @consume({ context: LayerService.context() })
+  accessor layerService!: LayerService;
+
+  private isSliderDragging = false;
+  private commitFrameId = 0;
+  private preloadSubscriptionAxis: Tiles3dLayerController | null = null;
+  /** The controller currently told to run background prefetching, so it can
+   * be told to stop again on disconnect (or if the controller changes). */
+  private hudActiveController: Tiles3dLayerController | null = null;
+  private preloadBannerHideTimer = 0;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+
+    this.register(
+      this.layerService.layer$(this.layerId).subscribe((layer) => {
+        this.layer = layer;
+        this.controller = this.layerService.controller(
+          layer.id,
+        ) as Tiles3dLayerController;
+
+        if (!this.isSliderDragging) {
+          this.draftSingle = layer.sliceSelection?.single ?? null;
+        }
+
+        // Multiple-slice mode is not released yet — always fall back to single.
+        if (layer.sliceSelection?.mode === 'multiple') {
+          this.updateSelection({ mode: 'single' });
+        }
+
+        this.bindPreloadProgress(this.controller);
+
+        if (this.controller?.supportsSliceSelection === true) {
+          this.activateHudPreload(this.controller);
+        }
+      }),
+    );
+  }
+
+  disconnectedCallback(): void {
+    this.hudActiveController?.setHudActive(false);
+    this.hudActiveController = null;
+    clearTimeout(this.preloadBannerHideTimer);
+    this.cancelScheduledCommit();
+    this.commitDraftSingle();
+    super.disconnectedCallback();
+  }
+
+  private bindPreloadProgress(controller: Tiles3dLayerController | null): void {
+    if (controller === null || controller === this.preloadSubscriptionAxis) {
+      return;
+    }
+    if (!controller.supportsSliceSelection) {
+      return;
+    }
+    this.preloadSubscriptionAxis = controller;
+    this.applyPreloadProgress(controller.getPreloadProgress());
+    this.register(
+      controller.preloadProgress.subscribe((progress) => {
+        this.applyPreloadProgress(progress);
+      }),
+    );
+  }
+
+  /**
+   * Tell the controller to (keep) run(ning) background slice prefetching for
+   * as long as this HUD panel stays open — see `Tiles3dLayerController.setHudActive`.
+   */
+  private activateHudPreload(controller: Tiles3dLayerController): void {
+    if (!controller.supportsSliceSelection) {
+      return;
+    }
+    if (
+      this.hudActiveController !== null &&
+      this.hudActiveController !== controller
+    ) {
+      this.hudActiveController.setHudActive(false);
+    }
+    this.hudActiveController = controller;
+    controller.setHudActive(true);
+    // Sync immediately in case the queue is already complete from a prior run.
+    this.applyPreloadProgress(controller.getPreloadProgress());
+  }
+
+  /**
+   * Decides whether the (subtle) preload banner should be shown, on top of
+   * just storing the raw progress for its text/percentage.
+   *
+   * - While actively loading: show it right away.
+   * - Once done: if it was visible (i.e. we actually watched slices load
+   *   during this session), leave it up a few seconds so the "done" state is
+   *   noticeable, then fade it out. If everything was already cached (so it
+   *   never showed a loading state at all), never show it — there's nothing
+   *   useful to report.
+   * - Idle (nothing to load): hidden.
+   */
+  private applyPreloadProgress(progress: SlicePreloadProgress): void {
+    this.preloadProgress = { ...progress, axes: { ...progress.axes } };
+
+    if (progress.status === 'loading') {
+      clearTimeout(this.preloadBannerHideTimer);
+      this.isPreloadBannerVisible = true;
+      return;
+    }
+
+    if (progress.status === 'done') {
+      if (this.isPreloadBannerVisible) {
+        clearTimeout(this.preloadBannerHideTimer);
+        this.preloadBannerHideTimer = window.setTimeout(() => {
+          this.isPreloadBannerVisible = false;
+        }, PRELOAD_BANNER_LINGER_MS);
+      }
+      return;
+    }
+
+    // idle — nothing queued.
+    clearTimeout(this.preloadBannerHideTimer);
+    this.isPreloadBannerVisible = false;
+  }
+
+  private get selection(): Tiles3dSliceSelection | null {
+    return this.layer?.sliceSelection ?? null;
+  }
+
+  private getSingleValue(axis: SeismicSliceAxis): number {
+    return this.draftSingle?.[axis] ?? this.selection?.single[axis] ?? 0;
+  }
+
+  private updateSelection(patch: Partial<Tiles3dSliceSelection>): void {
+    const current = this.selection;
+    if (current === null) {
+      return;
+    }
+    this.layerService.update(this.layerId, {
+      sliceSelection: {
+        ...current,
+        ...patch,
+        single: patch.single ?? current.single,
+        multiple: patch.multiple ?? current.multiple,
+      },
+    });
+  }
+
+  private readonly setMode = (mode: SliceViewMode): void => {
+    this.commitDraftSingle();
+    this.updateSelection({ mode });
+  };
+
+  private readonly setSingleSlice = (
+    axis: SeismicSliceAxis,
+    value: number,
+  ): void => {
+    const current = this.selection;
+    if (current === null) {
+      return;
+    }
+    const nextSingle = {
+      ...(this.draftSingle ?? current.single),
+      [axis]: value,
+    };
+    this.draftSingle = nextSingle;
+    this.controller?.prioritizeAxisNeighborhood(axis, value);
+    this.updateSelection({ single: nextSingle });
+  };
+
+  private readonly onSliderInput = (
+    axis: SeismicSliceAxis,
+    event: SliderChangeEvent,
+  ): void => {
+    const current = this.selection;
+    if (current === null) {
+      return;
+    }
+    this.isSliderDragging = true;
+    const value = Math.round(event.detail.value);
+    this.draftSingle = {
+      ...(this.draftSingle ?? current.single),
+      [axis]: value,
+    };
+    // Keep the HTTP cache ahead of the scrub position.
+    this.controller?.prioritizeAxisNeighborhood(axis, value);
+    // `input` fires per pointer move (~60/s). Committing each one floods the
+    // layer store and the tileset rebuild pipeline, so coalesce to one commit
+    // per animation frame. The exact final value is committed on `done`.
+    this.scheduleCommit();
+  };
+
+  private scheduleCommit(): void {
+    if (this.commitFrameId !== 0) {
+      return;
+    }
+    this.commitFrameId = requestAnimationFrame(() => {
+      this.commitFrameId = 0;
+      this.commitDraftSingle();
+    });
+  }
+
+  private cancelScheduledCommit(): void {
+    if (this.commitFrameId !== 0) {
+      cancelAnimationFrame(this.commitFrameId);
+      this.commitFrameId = 0;
+    }
+  }
+
+  private readonly onSliderDone = (): void => {
+    this.isSliderDragging = false;
+    this.cancelScheduledCommit();
+    this.commitDraftSingle();
+  };
+
+  private commitDraftSingle(): void {
+    const current = this.selection;
+    if (current === null || this.draftSingle === null) {
+      return;
+    }
+    const isUnchanged = SEISMIC_SLICE_AXES.every(
+      (axis) => this.draftSingle![axis] === current.single[axis],
+    );
+    if (isUnchanged) {
+      return;
+    }
+    this.updateSelection({ single: { ...this.draftSingle } });
+  }
+
+  private readonly setMultipleAxis = (axis: SeismicSliceAxis): void => {
+    const current = this.selection;
+    if (current === null) {
+      return;
+    }
+    this.updateSelection({
+      multiple: { ...current.multiple, axis },
+    });
+  };
+
+  private readonly setMultipleCount = (count: number): void => {
+    const current = this.selection;
+    if (current === null || this.controller === null) {
+      return;
+    }
+    const max = this.controller.getAxisNumbers(current.multiple.axis).length;
+    const clamped = Math.max(1, Math.min(count, Math.max(1, max)));
+    this.updateSelection({
+      multiple: { ...current.multiple, count: clamped },
+    });
+  };
+
+  readonly render = () => {
+    if (
+      this.controller === null ||
+      !this.controller.supportsSliceSelection ||
+      this.selection === null
+    ) {
+      return html``;
+    }
+
+    const { selection } = this;
+    return html`
+      <div class="panel">
+        <div class="controls">
+          ${this.renderPreloadBanner()}
+          <label class="mode">
+            <span class="mode-label"
+              >${i18next.t('catalog:slice_window.mode.label')}</span
+            >
+            <select
+              .value=${selection.mode}
+              @change=${(e: Event) =>
+                this.setMode(
+                  (e.target as HTMLSelectElement).value as SliceViewMode,
+                )}
+            >
+              <option value="single">
+                ${i18next.t('catalog:slice_window.mode.single')}
+              </option>
+              <option value="multiple" disabled>
+                ${i18next.t('catalog:slice_window.mode.multiple')} —
+                ${i18next.t('catalog:slice_window.mode.coming_soon')}
+              </option>
+            </select>
+          </label>
+
+          ${
+            selection.mode === 'single'
+              ? this.renderSingleMode()
+              : this.renderMultipleMode(selection)
+          }
+        </div>
+        ${this.renderLegend()}
+      </div>
+    `;
+  };
+
+  private readonly renderPreloadBanner = () => {
+    if (!this.isPreloadBannerVisible) {
+      return null;
+    }
+    const { preloadProgress } = this;
+    const pct = Math.round(
+      (preloadProgress.loaded / Math.max(1, preloadProgress.total)) * 100,
+    );
+    const isDone = preloadProgress.status === 'done';
+    return html`
+      <div class="preload-banner ${isDone ? 'is-done' : ''}" role="status">
+        <div class="preload-banner-label">
+          ${
+            isDone
+              ? i18next.t('catalog:slice_window.preload.done', {
+                  total: preloadProgress.total,
+                })
+              : i18next.t('catalog:slice_window.preload.loading', {
+                  loaded: preloadProgress.loaded,
+                  total: preloadProgress.total,
+                })
+          }
+        </div>
+        <div
+          class="progress"
+          role="progressbar"
+          aria-valuemin="0"
+          aria-valuemax="100"
+          aria-valuenow=${pct}
+        >
+          <div class="progress-bar" style="width: ${pct}%"></div>
+        </div>
+      </div>
+    `;
+  };
+
+  private readonly renderSingleMode = () => html`
+    <div class="axes">
+      ${SEISMIC_SLICE_AXES.map((axis) => {
+        const numbers = this.controller!.getAxisNumbers(axis);
+        if (numbers.length === 0) {
+          return null;
+        }
+        const min = numbers[0];
+        const max = numbers[numbers.length - 1];
+        const value = this.getSingleValue(axis);
+        return html`
+          <div class="axis">
+            <div class="axis-header">
+              <span class="axis-label">
+                ${i18next.t(`catalog:slice_window.${axis}`)}
+              </span>
+              ${this.renderStepper(value, min, max, (next) =>
+                this.setSingleSlice(axis, next),
+              )}
+            </div>
+            <ngm-core-slider
+              .value=${value}
+              .min=${min}
+              .max=${max}
+              .step=${1}
+              @change=${(e: SliderChangeEvent) => this.onSliderInput(axis, e)}
+              @done=${this.onSliderDone}
+            ></ngm-core-slider>
+          </div>
+        `;
+      })}
+    </div>
+  `;
+
+  private readonly renderMultipleMode = (selection: Tiles3dSliceSelection) => {
+    const { axis, count } = selection.multiple;
+    const numbers = this.controller!.getAxisNumbers(axis);
+    const maxCount = Math.max(1, numbers.length);
+    const recommended = RECOMMENDED_MAX_SLICES_BY_AXIS[axis];
+    const showWarning = count > recommended;
+
+    return html`
+      <div class="multiple">
+        <div class="type-radios" role="radiogroup">
+          ${SEISMIC_SLICE_AXES.map((candidate) => {
+            if (this.controller!.getAxisNumbers(candidate).length === 0) {
+              return null;
+            }
+            const isActive = candidate === axis;
+            return html`
+              <ngm-core-radio
+                .isActive=${isActive}
+                @click=${() => this.setMultipleAxis(candidate)}
+              >
+                ${i18next.t(`catalog:slice_window.${candidate}`)}
+              </ngm-core-radio>
+            `;
+          })}
+        </div>
+
+        <div class="amount">
+          <span class="amount-label">
+            ${i18next.t('catalog:slice_window.amount')}
+          </span>
+          ${this.renderStepper(count, 1, maxCount, this.setMultipleCount)}
+        </div>
+        ${when(
+          showWarning,
+          () => html`
+            <p class="warning">
+              ${i18next.t('catalog:slice_window.warning_large', {
+                max: recommended,
+                axis: i18next.t(`catalog:slice_window.${axis}`),
+              })}
+            </p>
+          `,
+        )}
+      </div>
+    `;
+  };
+
+  private readonly renderStepper = (
+    value: number,
+    min: number,
+    max: number,
+    onChange: (value: number) => void,
+  ) => html`
+    <div class="stepper">
+      <button
+        type="button"
+        class="stepper-btn"
+        ?disabled=${value <= min}
+        @click=${() => onChange(value - 1)}
+      >
+        &lt;
+      </button>
+      <input
+        type="number"
+        .value=${String(value)}
+        min=${min}
+        max=${max}
+        step="1"
+        @change=${(e: Event) => {
+          const raw = Number((e.target as HTMLInputElement).value);
+          if (Number.isNaN(raw)) {
+            return;
+          }
+          onChange(Math.max(min, Math.min(max, Math.round(raw))));
+        }}
+      />
+      <button
+        type="button"
+        class="stepper-btn"
+        ?disabled=${value >= max}
+        @click=${() => onChange(value + 1)}
+      >
+        &gt;
+      </button>
+    </div>
+  `;
+
+  private readonly renderLegend = () => html`
+    <aside class="legend">
+      <div class="legend-title">
+        ${i18next.t('catalog:slice_window.legend.relative_amplitude')}
+      </div>
+      <div class="legend-range">
+        <div class="legend-gradient"></div>
+        ${AMPLITUDE_LEGEND_STEPS.map(
+          (step) => html`
+            <div
+              class="legend-step"
+              style="--step-percentage: ${step.percentage}"
+            >
+              ${step.label}
+            </div>
+          `,
+        )}
+      </div>
+    </aside>
+  `;
+
+  static readonly styles = css`
+    :host,
+    :host * {
+      box-sizing: border-box;
+    }
+
+    :host {
+      display: block;
+      width: 520px;
+      min-height: 280px;
+    }
+
+    .panel {
+      display: flex;
+      width: 100%;
+      min-height: 280px;
+    }
+
+    .controls {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+      padding: 16px 24px;
+      width: calc(100% - 160px);
+    }
+
+    .preload-banner {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      opacity: 0.75;
+      transition: opacity 400ms ease;
+    }
+
+    .preload-banner-label {
+      ${applyTypography('caption')};
+      color: var(--sgc-color-text--emphasis-low, #999);
+    }
+
+    .preload-banner.is-done {
+      opacity: 0.6;
+    }
+
+    .preload-banner.is-done .preload-banner-label {
+      color: var(--color-primary--active, #607d52);
+    }
+
+    .progress {
+      width: 100%;
+      height: 3px;
+      border-radius: 2px;
+      background: var(--sgc-color-border--default, #ddd);
+      overflow: hidden;
+    }
+
+    .progress-bar {
+      height: 100%;
+      background: var(--sgc-color-text--emphasis-low, #999);
+      transition: width 120ms linear;
+    }
+
+    .preload-banner.is-done .progress-bar {
+      background: var(--color-primary--active, #607d52);
+    }
+
+    .mode {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .mode-label,
+    .axis-label,
+    .amount-label {
+      ${applyTypography('body-2-bold')};
+      color: var(--sgc-color-text--emphasis-high);
+    }
+
+    .mode select {
+      height: 36px;
+      padding: 0 12px;
+      border: 1px solid var(--sgc-color-border--default);
+      border-radius: 4px;
+      background: var(--sgc-color-bg--white);
+      ${applyTypography('body-2')};
+    }
+
+    .axes {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .axis {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .axis-header,
+    .amount {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .stepper {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .stepper input {
+      width: 64px;
+      height: 32px;
+      text-align: center;
+      border: 1px solid var(--sgc-color-border--default);
+      border-radius: 4px;
+      ${applyTypography('body-2')};
+    }
+
+    .stepper-btn {
+      width: 28px;
+      height: 32px;
+      border: 1px solid var(--sgc-color-border--default);
+      border-radius: 4px;
+      background: var(--sgc-color-bg--white);
+      cursor: pointer;
+      ${applyTypography('body-2')};
+    }
+
+    .stepper-btn:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+
+    .multiple {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .type-radios {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .warning {
+      margin: 0;
+      ${applyTypography('body-2')};
+      color: var(--sgc-color-error, #c62828);
+    }
+
+    .legend {
+      width: 160px;
+      padding: 16px;
+      border-left: 1px solid var(--sgc-color-border--default);
+      background-color: var(--sgc-color-bg--grey);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 16px;
+    }
+
+    .legend-title {
+      width: 100%;
+      padding-bottom: 12px;
+      border-bottom: 1px solid var(--sgc-color-border--emphasis-high);
+      text-align: center;
+      ${applyTypography('body-2-bold')};
+    }
+
+    .legend-range {
+      position: relative;
+      height: 100%;
+      min-height: 220px;
+      width: 90px;
+    }
+
+    .legend-gradient {
+      width: 36px;
+      height: 100%;
+      background: linear-gradient(
+        to bottom,
+        #ffffff 0%,
+        #f5d0c8 25%,
+        #e57373 50%,
+        #8d6e63 75%,
+        #424242 100%
+      );
+    }
+
+    .legend-step {
+      position: absolute;
+      top: calc((100% - 1px) * var(--step-percentage));
+      left: 48px;
+      height: 20px;
+      margin-top: -10px;
+      white-space: nowrap;
+      ${applyTypography('body-2')};
+    }
+
+    .legend-step::before {
+      display: block;
+      content: ' ';
+      background-color: var(--sgc-color-secondary--900, #333);
+      height: 1px;
+      width: 28px;
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+      right: 100%;
+      margin-right: 4px;
+    }
+  `;
+}
+
+const AMPLITUDE_LEGEND_STEPS: ReadonlyArray<{
+  label: string;
+  percentage: number;
+}> = [
+  { label: '0.20', percentage: 0 },
+  { label: '0.10', percentage: 0.2 },
+  { label: '0', percentage: 0.4 },
+  { label: '-0.10', percentage: 0.6 },
+  { label: '-0.20', percentage: 0.8 },
+  { label: 'NDV', percentage: 1 },
+];

--- a/ui/src/features/core/core-slider.element.ts
+++ b/ui/src/features/core/core-slider.element.ts
@@ -22,6 +22,10 @@ export class CoreSlider extends LitElement {
 
   handleInputChange(event: InputEvent) {
     this.value = (event.target as HTMLInputElement).valueAsNumber;
+    this.emitChange();
+  }
+
+  private emitChange() {
     this.dispatchEvent(
       new CustomEvent<SliderChangeEventDetail>('change', {
         detail: {
@@ -29,6 +33,51 @@ export class CoreSlider extends LitElement {
         },
       }),
     );
+  }
+
+  /**
+   * Arrow/Home/End keys are handled explicitly rather than relying on the
+   * native range behaviour, so that the value is clamped consistently and a
+   * `done` event is emitted for each discrete step (there is no pointerup).
+   */
+  handleKeyDown(event: KeyboardEvent) {
+    const step = this.step === 0 ? 1 : Math.abs(this.step);
+    let next: number | null = null;
+    switch (event.key) {
+      case 'ArrowLeft':
+      case 'ArrowDown':
+        next = this.value - step;
+        break;
+      case 'ArrowRight':
+      case 'ArrowUp':
+        next = this.value + step;
+        break;
+      case 'PageDown':
+        next = this.value - step * 10;
+        break;
+      case 'PageUp':
+        next = this.value + step * 10;
+        break;
+      case 'Home':
+        next = this.min;
+        break;
+      case 'End':
+        next = this.max;
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const clamped = Math.min(this.max, Math.max(this.min, next));
+    if (clamped === this.value) {
+      return;
+    }
+    this.value = clamped;
+    this.emitChange();
+    this.dispatchEvent(new CustomEvent('done'));
   }
 
   handlePointerUp(e: Event) {
@@ -50,6 +99,7 @@ export class CoreSlider extends LitElement {
       step=${this.step}
       .value=${live(isNaN(this.value) ? 1 : this.value)}
       @input=${this.handleInputChange}
+      @keydown=${this.handleKeyDown}
       @pointerdown="${stopEvent}"
       @pointerup=${this.handlePointerUp}
       @click="${stopEvent}"
@@ -101,6 +151,11 @@ export class CoreSlider extends LitElement {
     input[type='range']::-webkit-slider-runnable-track {
       border-radius: 4px;
       height: var(--slider-track-height);
+    }
+
+    input[type='range']:focus-visible {
+      outline: 2px solid var(--color-primary--active);
+      outline-offset: 6px;
     }
 
     input[type='range']::-moz-range-track {

--- a/ui/src/features/core/core-slider.element.ts
+++ b/ui/src/features/core/core-slider.element.ts
@@ -1,4 +1,4 @@
-import { css, html, LitElement } from 'lit';
+import { css, html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { live } from 'lit/directives/live.js';
@@ -7,6 +7,9 @@ import { live } from 'lit/directives/live.js';
 export class CoreSlider extends LitElement {
   @property({ type: Boolean })
   accessor isActive: boolean = false;
+
+  @property({ type: String })
+  accessor label: string = '';
 
   @property({ type: Number })
   accessor min: number = 0;
@@ -89,6 +92,7 @@ export class CoreSlider extends LitElement {
     <input
       type="range"
       class="ngm-slider"
+      aria-label=${this.label || nothing}
       style="${styleMap({
         '--value': this.value,
         '--min': this.min,

--- a/ui/src/features/layer/controllers/layer-background.controller.ts
+++ b/ui/src/features/layer/controllers/layer-background.controller.ts
@@ -35,8 +35,9 @@ export class BackgroundLayerController extends BaseLayerController<BackgroundLay
     this.watch(this.layer.isVisible, (isVisible) => {
       this.setLayerOpacity(isVisible ? this.layer.opacity : 0);
 
-      this.viewer.scene.globe.depthTestAgainstTerrain = isVisible;
-      this.viewer.scene.globe.show = isVisible;
+      const { globe } = this.viewer.scene;
+      globe.depthTestAgainstTerrain = isVisible;
+      globe.show = isVisible;
     });
 
     this.watch(this.layer.activeVariantId, (variantId) => {

--- a/ui/src/features/layer/controllers/layer-background.controller.ts
+++ b/ui/src/features/layer/controllers/layer-background.controller.ts
@@ -35,9 +35,8 @@ export class BackgroundLayerController extends BaseLayerController<BackgroundLay
     this.watch(this.layer.isVisible, (isVisible) => {
       this.setLayerOpacity(isVisible ? this.layer.opacity : 0);
 
-      const { globe } = this.viewer.scene;
-      globe.depthTestAgainstTerrain = isVisible;
-      globe.show = isVisible;
+      this.viewer.scene.globe.depthTestAgainstTerrain = isVisible;
+      this.viewer.scene.globe.show = isVisible;
     });
 
     this.watch(this.layer.activeVariantId, (variantId) => {

--- a/ui/src/features/layer/controllers/layer-tiff.controller.ts
+++ b/ui/src/features/layer/controllers/layer-tiff.controller.ts
@@ -169,6 +169,7 @@ export class TiffLayerController extends BaseLayerController<TiffLayer> {
 
       // Make the layer partially transparent to hide parts that are not covered by the imagery.
       isPartiallyTransparent: true,
+      sliceSelection: null,
     };
   }
 

--- a/ui/src/features/layer/controllers/layer-tiles3d.controller.ts
+++ b/ui/src/features/layer/controllers/layer-tiles3d.controller.ts
@@ -1,79 +1,497 @@
+import { BehaviorSubject, Observable } from 'rxjs';
 import {
   BaseLayerController,
   mapLayerSourceToResource,
 } from 'src/features/layer/controllers/layer.controller';
-import { LayerType, Tiles3dLayer } from 'src/features/layer';
+import { LayerSourceType, LayerType, Tiles3dLayer } from 'src/features/layer';
+import { LayerService } from 'src/features/layer/layer.service';
 import {
+  BoundingSphere,
   Cartesian2,
   Cesium3DTileset,
   CustomShader,
   CustomShaderTranslucencyMode,
   ImageBasedLighting,
+  Resource,
   UniformType,
 } from 'cesium';
 import { OBJECT_HIGHLIGHT_NORMALIZED_RGB } from 'src/constants';
 import { PickService, ScenePickingLock } from 'src/services/pick.service';
+import {
+  AXIS_TO_DIRECTION,
+  AxisTilesetSlot,
+  collectAxisSliceUriMap,
+  createAuthenticatedBlobResource,
+  createDefaultSliceSelection,
+  emptySlicePreloadProgress,
+  evenlySpacedSliceNumbers,
+  extractResourceHeaders,
+  hasSliceMetadata,
+  neighborhoodSliceNumbers,
+  orderNumbersFromCenter,
+  parseTilesetSliceMetadata,
+  resolveOgcTilesetResource,
+  ResolvedTileset,
+  SEISMIC_SLICE_AXES,
+  SeismicSliceAxis,
+  SLICE_GPU_WARM_RADIUS,
+  SLICE_PREFETCH_RADIUS,
+  SlicePreloadProgress,
+  SlicePreloadQueue,
+  TILESET_OPTIONS,
+  Tiles3dSliceSelection,
+  TilesetSliceMetadata,
+  toBlobUrl,
+} from 'src/features/layer/slice';
 
 export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
   private _tileset!: Cesium3DTileset;
-
   private scenePickingLock: ScenePickingLock | null = null;
+
+  private originalTilesetJson: unknown = null;
+  private baseUrl = '';
+  private resourceHeaders: Record<string, string> = {};
+  private sliceMetadata: TilesetSliceMetadata | null = null;
+  private defaultSliceSelection: Tiles3dSliceSelection | null = null;
+  private readonly axisSlots = new Map<SeismicSliceAxis, AxisTilesetSlot>();
+  /** JSON-serialized slice numbers last applied per axis (skip unchanged rebuilds). */
+  private readonly appliedNumbersByAxis = new Map<SeismicSliceAxis, string>();
+  private preloadQueue: SlicePreloadQueue | null = null;
+  /**
+   * Background prefetching (warming the HTTP cache / building neighbouring
+   * GPU tilesets for every axis) is only useful while the slice HUD panel
+   * (with its sliders) is actually open — that's the only place slices are
+   * scrubbed through quickly. Toggled by `setHudActive` from the panel's
+   * connect/disconnect lifecycle; gates `startAxisPreload`,
+   * `prioritizeAxisNeighborhood` and `warmAxisNeighborhood` below.
+   */
+  private isHudActive = false;
+  /** Memoized `slice number -> content URI` per axis (walking the tileset JSON
+   * is O(nodes) and used to run on every slider input event). */
+  private readonly uriMapByAxis = new Map<
+    SeismicSliceAxis,
+    Map<number, string>
+  >();
+  private readonly preloadProgress$ = new BehaviorSubject<SlicePreloadProgress>(
+    emptySlicePreloadProgress(),
+  );
 
   get type(): LayerType.Tiles3d {
     return LayerType.Tiles3d;
   }
 
   get tileset(): Cesium3DTileset {
+    for (const axis of SEISMIC_SLICE_AXES) {
+      const slotTileset = this.axisSlots.get(axis)?.currentTileset;
+      if (slotTileset !== null && slotTileset !== undefined) {
+        return slotTileset;
+      }
+    }
     return this._tileset;
   }
 
+  get supportsSliceSelection(): boolean {
+    return hasSliceMetadata(this.sliceMetadata);
+  }
+
+  getSliceMetadata(): TilesetSliceMetadata | null {
+    return this.sliceMetadata;
+  }
+
+  getDefaultSliceSelection(): Tiles3dSliceSelection | null {
+    return this.defaultSliceSelection;
+  }
+
+  getAxisNumbers(axis: SeismicSliceAxis): number[] {
+    return this.sliceMetadata?.axes[axis]?.numbers ?? [];
+  }
+
+  get preloadProgress(): Observable<SlicePreloadProgress> {
+    return this.preloadProgress$.asObservable();
+  }
+
+  getPreloadProgress(): SlicePreloadProgress {
+    return this.preloadProgress$.value;
+  }
+
+  /**
+   * Enable or disable background slice prefetching. Called by the slice HUD
+   * panel from its connect/disconnect lifecycle, so prefetching only runs
+   * while the panel (with its sliders) is actually open, instead of eagerly
+   * warming every slice as soon as the layer is activated.
+   */
+  setHudActive(active: boolean): void {
+    if (this.isHudActive === active) {
+      return;
+    }
+    this.isHudActive = active;
+    if (active) {
+      this.startAxisPreload();
+    } else {
+      this.pausePreload();
+    }
+  }
+
+  /**
+   * Warm the HTTP cache for every slice GLB on each axis (center-out from the
+   * current selection). Safe to call repeatedly; already-queued URLs are skipped.
+   * No-op while the slice HUD panel isn't open (see `setHudActive`).
+   */
+  startAxisPreload(
+    selection: Tiles3dSliceSelection | null = this.layer.sliceSelection,
+  ): void {
+    if (
+      !this.isHudActive ||
+      this.originalTilesetJson === null ||
+      !this.supportsSliceSelection ||
+      this.sliceMetadata === null
+    ) {
+      return;
+    }
+
+    this.ensurePreloadQueue();
+    const centers = selection?.single ?? this.defaultSliceSelection?.single;
+
+    for (const axis of SEISMIC_SLICE_AXES) {
+      const available = this.getAxisNumbers(axis);
+      if (available.length === 0) {
+        continue;
+      }
+      const uriByNumber = this.getAxisUriMap(axis);
+      const center =
+        centers?.[axis] ?? available[Math.floor(available.length / 2)];
+      const ordered = orderNumbersFromCenter(available, center);
+      const urls = ordered
+        .map((number) => uriByNumber.get(number))
+        .filter((url): url is string => url !== undefined);
+      this.preloadQueue!.enqueue(axis, urls, false);
+    }
+  }
+
+  /** Lazily built and cached; the tileset JSON never changes after load. */
+  private getAxisUriMap(axis: SeismicSliceAxis): Map<number, string> {
+    let map = this.uriMapByAxis.get(axis);
+    if (map === undefined) {
+      map = collectAxisSliceUriMap(
+        this.originalTilesetJson,
+        AXIS_TO_DIRECTION[axis],
+      );
+      this.uriMapByAxis.set(axis, map);
+    }
+    return map;
+  }
+
+  /**
+   * Bump nearby slices for one axis to the front of the preload queue so
+   * scrubbing stays responsive while the full-axis warm-up continues.
+   * No-op while the slice HUD panel isn't open (see `setHudActive`).
+   */
+  prioritizeAxisNeighborhood(
+    axis: SeismicSliceAxis,
+    center: number,
+    radius: number = SLICE_PREFETCH_RADIUS,
+  ): void {
+    if (
+      !this.isHudActive ||
+      this.originalTilesetJson === null ||
+      !this.supportsSliceSelection
+    ) {
+      return;
+    }
+    this.ensurePreloadQueue();
+    const available = this.getAxisNumbers(axis);
+    const neighbors = neighborhoodSliceNumbers(available, center, radius);
+    const uriByNumber = this.getAxisUriMap(axis);
+    const urls = neighbors
+      .map((number) => uriByNumber.get(number))
+      .filter((url): url is string => url !== undefined);
+    this.preloadQueue!.enqueue(axis, urls, true);
+  }
+
+  /**
+   * Build and load the tilesets for the slices immediately around `center` so
+   * that stepping to a neighbour is a pure visibility flip.
+   *
+   * The HTTP prefetch queue only warms the browser cache; the expensive part of
+   * a swap (glTF parse, texture decode, GPU upload) happens here instead, ahead
+   * of time and off the interaction path.
+   * No-op while the slice HUD panel isn't open (see `setHudActive`).
+   */
+  private warmAxisNeighborhood(
+    axis: SeismicSliceAxis,
+    center: number,
+    radius: number = SLICE_GPU_WARM_RADIUS,
+  ): void {
+    if (!this.isHudActive) {
+      return;
+    }
+    const slot = this.axisSlots.get(axis);
+    if (slot === undefined || this.originalTilesetJson === null) {
+      return;
+    }
+    const available = this.getAxisNumbers(axis);
+    const neighbors = neighborhoodSliceNumbers(available, center, radius)
+      .filter((number) => number !== center)
+      .sort((a, b) => Math.abs(a - center) - Math.abs(b - center));
+    if (neighbors.length === 0) {
+      return;
+    }
+    void slot.warmSlices(
+      this.originalTilesetJson,
+      this.baseUrl,
+      this.resourceHeaders,
+      AXIS_TO_DIRECTION[axis],
+      neighbors,
+    );
+  }
+
+  private ensurePreloadQueue(): void {
+    if (this.preloadQueue !== null) {
+      return;
+    }
+    this.preloadQueue = new SlicePreloadQueue({
+      headers: this.resourceHeaders,
+      onProgress: (progress) => this.preloadProgress$.next(progress),
+    });
+  }
+
+  /**
+   * Stop background prefetching while the HUD is closed, without discarding
+   * the queue's "already completed" bookkeeping — so reopening the HUD later
+   * doesn't re-preload slices that were already fetched/warmed. Only
+   * in-flight/pending network work is cancelled; already-completed URLs stay
+   * remembered on the same `SlicePreloadQueue` instance.
+   */
+  private pausePreload(): void {
+    this.preloadQueue?.abortAndClear();
+  }
+
+  /**
+   * Fully tear down preloading (used when the layer itself is deactivated) —
+   * unlike {@link pausePreload}, this also discards the queue's bookkeeping,
+   * since the underlying tileset/slice data is being torn down too.
+   */
+  private stopPreload(): void {
+    this.preloadQueue?.abortAndClear();
+    this.preloadQueue = null;
+    this.preloadProgress$.next(emptySlicePreloadProgress());
+  }
+
   zoomIntoView(): void {
-    this.viewer.flyTo(this.tileset).then();
+    void this.zoomIntoViewAsync();
+  }
+
+  private async zoomIntoViewAsync(): Promise<void> {
+    // Bounding spheres for the axis tilesets may not be ready yet (e.g. the
+    // slice just finished loading a moment ago, or the user clicks the zoom
+    // button right after activating the layer); wait briefly instead of
+    // flying to a degenerate/empty sphere.
+    const sphere = await this.waitForVisibleBoundingSphere();
+    if (sphere === null) {
+      return;
+    }
+    // Use Cesium's default framing, like every other 3D-tiles/voxel layer
+    // (`flyToBoundingSphere(sphere)` with no custom offset). A previous,
+    // deliberately close/oblique framing (biased toward the surface, tilted
+    // pitch) was used to avoid seeing thin vertical slices edge-on from
+    // nadir, but it always left the camera very close to the tileset in a
+    // near-horizontal pose — exactly the regime where the map-panning
+    // controller's "vertical drag" math degenerates into an elevation change
+    // instead of a pan (see camera-controller.service.ts). Consistency with
+    // other layers' zoom behavior matters more than avoiding a possibly
+    // edge-on initial view.
+    this.viewer.camera.flyToBoundingSphere(sphere, { duration: 0.6 });
+  }
+
+  private async waitForVisibleBoundingSphere(
+    timeoutMs = 8_000,
+  ): Promise<BoundingSphere | null> {
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < timeoutMs) {
+      const sphere = this.computeVisibleBoundingSphere();
+      if (sphere !== null && sphere.radius > 1) {
+        return sphere;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      this.viewer.scene.requestRender();
+    }
+    return this.computeVisibleBoundingSphere();
+  }
+
+  private computeVisibleBoundingSphere(): BoundingSphere | null {
+    const spheres: BoundingSphere[] = [];
+    if (this.supportsSliceSelection) {
+      for (const axis of SEISMIC_SLICE_AXES) {
+        const tileset = this.axisSlots.get(axis)?.currentTileset;
+        if (tileset?.boundingSphere !== undefined) {
+          spheres.push(BoundingSphere.clone(tileset.boundingSphere));
+        }
+      }
+    } else if (this._tileset?.boundingSphere !== undefined) {
+      spheres.push(BoundingSphere.clone(this._tileset.boundingSphere));
+    }
+    if (spheres.length === 0) {
+      return null;
+    }
+    let union = spheres[0];
+    for (let i = 1; i < spheres.length; i++) {
+      union = BoundingSphere.union(union, spheres[i], union);
+    }
+    return union;
   }
 
   moveToTop(): void {
-    this.viewer.scene.primitives.raiseToTop(this.tileset);
+    if (this.supportsSliceSelection) {
+      for (const axis of SEISMIC_SLICE_AXES) {
+        this.axisSlots.get(axis)?.raiseToTop();
+      }
+      return;
+    }
+    if (this._tileset !== undefined) {
+      this.viewer.scene.primitives.raiseToTop(this._tileset);
+    }
   }
 
   protected reactToChanges(): void {
     this.watch(this.layer.source);
 
-    // Apply opacity to the Cesium layer.
     this.watch(this.layer.opacity, (opacity, previousOpacity) => {
+      if (this.supportsSliceSelection) {
+        for (const axis of SEISMIC_SLICE_AXES) {
+          this.axisSlots.get(axis)?.setOpacity(opacity);
+        }
+        return;
+      }
+      if (this._tileset === undefined) {
+        return;
+      }
       if (opacity === 1 || previousOpacity === 1) {
-        this.tileset.customShader = this.makeShader();
+        this._tileset.customShader = this.makeShader();
       } else {
-        const shader = this.tileset.customShader!;
-        shader.setUniform('u_alpha', opacity);
+        this._tileset.customShader!.setUniform('u_alpha', opacity);
       }
     });
 
-    // Show or hide the Cesium layer.
     this.watch(this.layer.isVisible, (isVisible) => {
-      this.tileset.show = isVisible;
+      if (this.supportsSliceSelection) {
+        for (const axis of SEISMIC_SLICE_AXES) {
+          this.axisSlots.get(axis)?.setVisible(isVisible);
+        }
+        return;
+      }
+      if (this._tileset !== undefined) {
+        this._tileset.show = isVisible;
+      }
+    });
+
+    this.watch(this.layer.sliceSelection, (selection) => {
+      if (selection === null || !this.supportsSliceSelection) {
+        return;
+      }
+      void this.applySliceSelection(selection);
     });
   }
 
   protected async addToViewer(): Promise<void> {
     const resource = await mapLayerSourceToResource(this.layer.source);
+
+    if (this.layer.source.type === LayerSourceType.Ogc) {
+      try {
+        const resolved = await resolveOgcTilesetResource(
+          resource.url,
+          extractResourceHeaders(resource),
+        );
+        const metadata = parseTilesetSliceMetadata(resolved.json);
+        if (hasSliceMetadata(metadata)) {
+          await this.addSliceAwareTilesets(resolved, metadata);
+          return;
+        }
+        await this.addFullTilesetFromResolved(resolved);
+        return;
+      } catch (error) {
+        console.error('Failed to resolve OGC tileset, falling back:', error);
+      }
+    }
+
+    await this.addFullTileset(resource);
+  }
+
+  protected removeFromViewer(): void {
+    this.stopPreload();
+    this.isHudActive = false;
+    this.destroyAxisSlots();
+    this.destroyFullTileset();
+    this.originalTilesetJson = null;
+    this.baseUrl = '';
+    this.resourceHeaders = {};
+    this.sliceMetadata = null;
+    this.defaultSliceSelection = null;
+    this.appliedNumbersByAxis.clear();
+    this.uriMapByAxis.clear();
+  }
+
+  private async addSliceAwareTilesets(
+    resolved: ResolvedTileset,
+    metadata: TilesetSliceMetadata,
+  ): Promise<void> {
+    this.destroyFullTileset();
+    this.destroyAxisSlots();
+
+    this.originalTilesetJson = resolved.json;
+    this.baseUrl = resolved.baseUrl;
+    this.resourceHeaders = resolved.headers;
+    this.sliceMetadata = metadata;
+    this.defaultSliceSelection = createDefaultSliceSelection(metadata);
+
+    for (const axis of SEISMIC_SLICE_AXES) {
+      if (metadata.axes[axis] === undefined) {
+        continue;
+      }
+      this.axisSlots.set(
+        axis,
+        new AxisTilesetSlot({
+          viewer: this.viewer,
+          makeShader: () => this.makeShader(),
+          getOpacity: () => this.layer.opacity,
+          getVisibility: () => this.layer.isVisible,
+        }),
+      );
+    }
+
+    const selection = this.layer.sliceSelection ?? this.defaultSliceSelection;
+    await this.applySliceSelection(selection);
+
+    // Background prefetching only starts once the HUD panel is opened (see
+    // `setHudActive`) — no automatic warm-up here.
+
+    const isInitialSelection = this.layer.sliceSelection === null;
+    if (isInitialSelection) {
+      LayerService.get().update(this.layer.id, { sliceSelection: selection });
+    }
+  }
+
+  private async addFullTilesetFromResolved(
+    resolved: ResolvedTileset,
+  ): Promise<void> {
+    const blobUrl = toBlobUrl(resolved.json);
+    const resource = createAuthenticatedBlobResource(blobUrl, resolved.headers);
+    try {
+      await this.addFullTileset(resource);
+    } finally {
+      // Cesium keeps using the blob URL via the Resource; revoke on remove.
+      // Store for cleanup by piggy-backing on baseUrl when not slice-aware.
+      this.baseUrl = blobUrl;
+    }
+  }
+
+  private async addFullTileset(resource: Resource): Promise<void> {
+    this.destroyAxisSlots();
+    this.sliceMetadata = null;
+    this.defaultSliceSelection = null;
+
     const tileset = await Cesium3DTileset.fromUrl(resource, {
+      ...TILESET_OPTIONS,
       show: true,
-      backFaceCulling: false,
-
-      // This feature flag has major performance implications. We turn it off so that large tilesets are performant.
-      enableCollision: false,
-
-      maximumScreenSpaceError: 16,
-      cullWithChildrenBounds: true,
-      cullRequestsWhileMoving: true,
-      cullRequestsWhileMovingMultiplier: 100,
-      preloadWhenHidden: false,
-      preferLeaves: true,
-      dynamicScreenSpaceError: true,
-      foveatedScreenSpaceError: true,
-      foveatedConeSize: 0.2,
-      foveatedMinimumScreenSpaceErrorRelaxation: 3,
-      foveatedTimeDelay: 0.2,
     });
 
     tileset.imageBasedLighting = new ImageBasedLighting();
@@ -85,13 +503,13 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
 
     const { primitives } = this.viewer.scene;
     const i =
-      this.tileset === null ? null : this.findIndexInPrimitives(this.tileset);
+      this._tileset === undefined || this._tileset === null
+        ? null
+        : this.findIndexInPrimitives(this._tileset);
     if (i === null) {
-      // Add a new Cesium layer.
       primitives.add(tileset);
     } else {
-      // Replace an existing Cesium layer.
-      this.removeFromViewer();
+      this.destroyFullTileset();
       primitives.add(tileset, i);
     }
 
@@ -109,19 +527,114 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
     );
   }
 
-  protected removeFromViewer(): void {
-    const { tileset } = this;
-    if (tileset === undefined) {
+  private async applySliceSelection(
+    selection: Tiles3dSliceSelection,
+  ): Promise<void> {
+    if (
+      this.originalTilesetJson === null ||
+      this.sliceMetadata === null ||
+      this.axisSlots.size === 0
+    ) {
       return;
     }
-    this.viewer.scene.primitives.remove(tileset);
-    if (!tileset.isDestroyed()) {
-      tileset.destroy();
-    }
-    this._tileset = undefined as unknown as Cesium3DTileset;
 
+    const numbersByAxis = this.resolveNumbersByAxis(selection);
+    const updates: Array<Promise<void>> = [];
+
+    for (const axis of SEISMIC_SLICE_AXES) {
+      const slot = this.axisSlots.get(axis);
+      if (slot === undefined) {
+        continue;
+      }
+      const numbers = numbersByAxis[axis] ?? [];
+      const numbersKey = JSON.stringify(numbers);
+      if (this.appliedNumbersByAxis.get(axis) === numbersKey) {
+        continue;
+      }
+      this.appliedNumbersByAxis.set(axis, numbersKey);
+
+      if (numbers.length === 0) {
+        slot.clear();
+        continue;
+      }
+      updates.push(
+        slot.setSlices(
+          this.originalTilesetJson,
+          this.baseUrl,
+          this.resourceHeaders,
+          AXIS_TO_DIRECTION[axis],
+          numbers,
+        ),
+      );
+    }
+
+    await Promise.all(updates);
+    if (selection.mode === 'single') {
+      for (const axis of SEISMIC_SLICE_AXES) {
+        const center = selection.single[axis];
+        this.prioritizeAxisNeighborhood(axis, center);
+        this.warmAxisNeighborhood(axis, center);
+      }
+    } else {
+      this.startAxisPreload(selection);
+    }
+  }
+
+  private resolveNumbersByAxis(
+    selection: Tiles3dSliceSelection,
+  ): Partial<Record<SeismicSliceAxis, number[]>> {
+    const result: Partial<Record<SeismicSliceAxis, number[]>> = {};
+    if (selection.mode === 'single') {
+      for (const axis of SEISMIC_SLICE_AXES) {
+        const available = this.getAxisNumbers(axis);
+        if (available.length === 0) {
+          continue;
+        }
+        const selected = selection.single[axis];
+        result[axis] = available.includes(selected)
+          ? [selected]
+          : [available[Math.floor(available.length / 2)]];
+      }
+      return result;
+    }
+
+    // Multiple: only the active axis shows evenly spaced slices.
+    for (const axis of SEISMIC_SLICE_AXES) {
+      if (axis !== selection.multiple.axis) {
+        result[axis] = [];
+        continue;
+      }
+      const available = this.getAxisNumbers(axis);
+      result[axis] = evenlySpacedSliceNumbers(
+        available,
+        selection.multiple.count,
+      );
+    }
+    return result;
+  }
+
+  private destroyAxisSlots(): void {
+    for (const slot of this.axisSlots.values()) {
+      slot.destroy();
+    }
+    this.axisSlots.clear();
+  }
+
+  private destroyFullTileset(): void {
+    const tileset = this._tileset;
+    if (tileset !== undefined) {
+      this.viewer.scene.primitives.remove(tileset);
+      if (!tileset.isDestroyed()) {
+        tileset.destroy();
+      }
+      this._tileset = undefined as unknown as Cesium3DTileset;
+    }
     this.scenePickingLock?.release();
     this.scenePickingLock = null;
+    if (this.baseUrl.startsWith('blob:')) {
+      URL.revokeObjectURL(this.baseUrl);
+      this.baseUrl = '';
+    }
   }
 
   private makeShader(): CustomShader {

--- a/ui/src/features/layer/controllers/layer-tiles3d.controller.ts
+++ b/ui/src/features/layer/controllers/layer-tiles3d.controller.ts
@@ -57,6 +57,8 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
   /** JSON-serialized slice numbers last applied per axis (skip unchanged rebuilds). */
   private readonly appliedNumbersByAxis = new Map<SeismicSliceAxis, string>();
   private preloadQueue: SlicePreloadQueue | null = null;
+  /** Bumped on every `zoomIntoView()` call so a superseded background refinement fly is dropped. */
+  private zoomGeneration = 0;
   /**
    * Background prefetching (warming the HTTP cache / building neighbouring
    * GPU tilesets for every axis) is only useful while the slice HUD panel
@@ -297,14 +299,33 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
   }
 
   private async zoomIntoViewAsync(): Promise<void> {
+    const zoomToken = ++this.zoomGeneration;
     // Bounding spheres for the axis tilesets may not be ready yet (e.g. the
     // slice just finished loading a moment ago, or the user clicks the zoom
-    // button right after activating the layer); wait briefly instead of
-    // flying to a degenerate/empty sphere.
-    const sphere = await this.waitForVisibleBoundingSphere();
-    if (sphere === null) {
+    // button right after activating the layer); wait briefly for a first,
+    // possibly-partial sphere instead of flying to a degenerate/empty one.
+    const firstSphere = await this.waitForAnyBoundingSphere();
+    if (firstSphere === null || zoomToken !== this.zoomGeneration) {
       return;
     }
+    this.flyToSphere(firstSphere);
+
+    if (this.allAxisSlotsReady()) {
+      return;
+    }
+    // Not every axis was ready yet: refine the framing once, in the
+    // background, to the full three-plane union — without blocking the
+    // initial fly above. Mirrors the double-buffered slice swap elsewhere in
+    // this file: never withhold what's already available, only replace it
+    // once the better version is ready.
+    const completeSphere = await this.waitForAllAxesBoundingSphere();
+    if (completeSphere === null || zoomToken !== this.zoomGeneration) {
+      return;
+    }
+    this.flyToSphere(completeSphere);
+  }
+
+  private flyToSphere(sphere: BoundingSphere): void {
     // Use Cesium's default framing, like every other 3D-tiles/voxel layer
     // (`flyToBoundingSphere(sphere)` with no custom offset). A previous,
     // deliberately close/oblique framing (biased toward the surface, tilted
@@ -318,8 +339,9 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
     this.viewer.camera.flyToBoundingSphere(sphere, { duration: 0.6 });
   }
 
-  private async waitForVisibleBoundingSphere(
-    timeoutMs = 8_000,
+  /** First non-degenerate sphere available, however partial. Fast/non-blocking. */
+  private async waitForAnyBoundingSphere(
+    timeoutMs = 2_000,
   ): Promise<BoundingSphere | null> {
     const startedAt = Date.now();
     while (Date.now() - startedAt < timeoutMs) {
@@ -331,6 +353,56 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
       this.viewer.scene.requestRender();
     }
     return this.computeVisibleBoundingSphere();
+  }
+
+  /** Union sphere once every axis slot participating in the selection is ready. */
+  private async waitForAllAxesBoundingSphere(
+    timeoutMs = 8_000,
+  ): Promise<BoundingSphere | null> {
+    const startedAt = Date.now();
+    let best: BoundingSphere | null = null;
+    while (Date.now() - startedAt < timeoutMs) {
+      const sphere = this.computeVisibleBoundingSphere();
+      if (sphere !== null && sphere.radius > 1) {
+        best = sphere;
+        if (this.allAxisSlotsReady()) {
+          return sphere;
+        }
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      this.viewer.scene.requestRender();
+    }
+    // Timed out before every axis was ready — fall back to whichever
+    // (possibly partial) union we already have, rather than nothing.
+    return best ?? this.computeVisibleBoundingSphere();
+  }
+
+  /**
+   * Whether every axis slot that participates in the current slice
+   * selection has a tileset with a resolved bounding sphere. Used so
+   * `waitForAllAxesBoundingSphere` frames the union of all three planes
+   * instead of stopping as soon as the first (possibly small/narrow) one
+   * happens to be ready — otherwise "zoom to object" can end up framing a
+   * single thin plane edge-on, making it fill the view and look far more
+   * extreme (e.g. much "deeper") than the whole slice cube actually is.
+   */
+  private allAxisSlotsReady(): boolean {
+    if (!this.supportsSliceSelection) {
+      return this._tileset?.boundingSphere !== undefined;
+    }
+    for (const axis of SEISMIC_SLICE_AXES) {
+      const slot = this.axisSlots.get(axis);
+      if (slot === undefined) {
+        continue;
+      }
+      if (this.getAxisNumbers(axis).length === 0) {
+        continue;
+      }
+      if (slot.currentTileset?.boundingSphere === undefined) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private computeVisibleBoundingSphere(): BoundingSphere | null {

--- a/ui/src/features/layer/controllers/layer-tiles3d.controller.ts
+++ b/ui/src/features/layer/controllers/layer-tiles3d.controller.ts
@@ -20,6 +20,7 @@ import { PickService, ScenePickingLock } from 'src/services/pick.service';
 import {
   AXIS_TO_DIRECTION,
   AxisTilesetSlot,
+  absolutizeTilesetUris,
   collectAxisSliceUriMap,
   createAuthenticatedBlobResource,
   createDefaultSliceSelection,
@@ -38,7 +39,6 @@ import {
   SLICE_PREFETCH_RADIUS,
   SlicePreloadProgress,
   SlicePreloadQueue,
-  TILESET_OPTIONS,
   Tiles3dSliceSelection,
   TilesetSliceMetadata,
   toBlobUrl,
@@ -88,6 +88,20 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
       }
     }
     return this._tileset;
+  }
+
+  get tilesets(): Cesium3DTileset[] {
+    const axisTs: Cesium3DTileset[] = [];
+    for (const axis of SEISMIC_SLICE_AXES) {
+      const slotTileset = this.axisSlots.get(axis)?.currentTileset;
+      if (slotTileset !== null && slotTileset !== undefined) {
+        axisTs.push(slotTileset);
+      }
+    }
+    if (axisTs.length > 0) {
+      return axisTs;
+    }
+    return this._tileset !== undefined ? [this._tileset] : [];
   }
 
   get supportsSliceSelection(): boolean {
@@ -175,6 +189,7 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
       map = collectAxisSliceUriMap(
         this.originalTilesetJson,
         AXIS_TO_DIRECTION[axis],
+        this.baseUrl,
       );
       this.uriMapByAxis.set(axis, map);
     }
@@ -395,7 +410,10 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
   protected async addToViewer(): Promise<void> {
     const resource = await mapLayerSourceToResource(this.layer.source);
 
-    if (this.layer.source.type === LayerSourceType.Ogc) {
+    if (
+      this.layer.source.type === LayerSourceType.Ogc &&
+      this.layer.source.displaySource === undefined
+    ) {
       try {
         const resolved = await resolveOgcTilesetResource(
           resource.url,
@@ -473,7 +491,8 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
   private async addFullTilesetFromResolved(
     resolved: ResolvedTileset,
   ): Promise<void> {
-    const blobUrl = toBlobUrl(resolved.json);
+    const absoluteJson = absolutizeTilesetUris(resolved.json, resolved.baseUrl);
+    const blobUrl = toBlobUrl(absoluteJson);
     const resource = createAuthenticatedBlobResource(blobUrl, resolved.headers);
     try {
       await this.addFullTileset(resource);
@@ -490,7 +509,6 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
     this.defaultSliceSelection = null;
 
     const tileset = await Cesium3DTileset.fromUrl(resource, {
-      ...TILESET_OPTIONS,
       show: true,
     });
 

--- a/ui/src/features/layer/controllers/layer-tiles3d.controller.ts
+++ b/ui/src/features/layer/controllers/layer-tiles3d.controller.ts
@@ -304,7 +304,7 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
     // slice just finished loading a moment ago, or the user clicks the zoom
     // button right after activating the layer); wait briefly for a first,
     // possibly-partial sphere instead of flying to a degenerate/empty one.
-    const firstSphere = await this.waitForAnyBoundingSphere();
+    const firstSphere = await this.waitForBoundingSphere(2_000, () => true);
     if (firstSphere === null || zoomToken !== this.zoomGeneration) {
       return;
     }
@@ -318,7 +318,9 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
     // initial fly above. Mirrors the double-buffered slice swap elsewhere in
     // this file: never withhold what's already available, only replace it
     // once the better version is ready.
-    const completeSphere = await this.waitForAllAxesBoundingSphere();
+    const completeSphere = await this.waitForBoundingSphere(8_000, () =>
+      this.allAxisSlotsReady(),
+    );
     if (completeSphere === null || zoomToken !== this.zoomGeneration) {
       return;
     }
@@ -339,25 +341,18 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
     this.viewer.camera.flyToBoundingSphere(sphere, { duration: 0.6 });
   }
 
-  /** First non-degenerate sphere available, however partial. Fast/non-blocking. */
-  private async waitForAnyBoundingSphere(
-    timeoutMs = 2_000,
-  ): Promise<BoundingSphere | null> {
-    const startedAt = Date.now();
-    while (Date.now() - startedAt < timeoutMs) {
-      const sphere = this.computeVisibleBoundingSphere();
-      if (sphere !== null && sphere.radius > 1) {
-        return sphere;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      this.viewer.scene.requestRender();
-    }
-    return this.computeVisibleBoundingSphere();
-  }
-
-  /** Union sphere once every axis slot participating in the selection is ready. */
-  private async waitForAllAxesBoundingSphere(
-    timeoutMs = 8_000,
+  /**
+   * Poll `computeVisibleBoundingSphere()` until `isDone` accepts a
+   * non-degenerate sphere or `timeoutMs` elapses, requesting a render
+   * between attempts (spheres only populate as Cesium's tile loading
+   * advances, which needs render ticks to proceed). Falls back to the best
+   * sphere seen so far (possibly none) once timed out — used both for the
+   * "any sphere, fast" and "every axis ready" waits below, which differ only
+   * in their stop condition and timeout.
+   */
+  private async waitForBoundingSphere(
+    timeoutMs: number,
+    isDone: () => boolean,
   ): Promise<BoundingSphere | null> {
     const startedAt = Date.now();
     let best: BoundingSphere | null = null;
@@ -365,26 +360,27 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
       const sphere = this.computeVisibleBoundingSphere();
       if (sphere !== null && sphere.radius > 1) {
         best = sphere;
-        if (this.allAxisSlotsReady()) {
+        if (isDone()) {
           return sphere;
         }
       }
       await new Promise((resolve) => setTimeout(resolve, 50));
       this.viewer.scene.requestRender();
     }
-    // Timed out before every axis was ready — fall back to whichever
-    // (possibly partial) union we already have, rather than nothing.
+    // Timed out before `isDone` was satisfied — fall back to whichever
+    // (possibly partial, possibly null) sphere we already have.
     return best ?? this.computeVisibleBoundingSphere();
   }
 
   /**
    * Whether every axis slot that participates in the current slice
    * selection has a tileset with a resolved bounding sphere. Used so
-   * `waitForAllAxesBoundingSphere` frames the union of all three planes
-   * instead of stopping as soon as the first (possibly small/narrow) one
-   * happens to be ready — otherwise "zoom to object" can end up framing a
-   * single thin plane edge-on, making it fill the view and look far more
-   * extreme (e.g. much "deeper") than the whole slice cube actually is.
+   * `waitForBoundingSphere`'s "every axis ready" wait frames the union of
+   * all three planes instead of stopping as soon as the first (possibly
+   * small/narrow) one happens to be ready — otherwise "zoom to object" can
+   * end up framing a single thin plane edge-on, making it fill the view and
+   * look far more extreme (e.g. much "deeper") than the whole slice cube
+   * actually is.
    */
   private allAxisSlotsReady(): boolean {
     if (!this.supportsSliceSelection) {
@@ -582,6 +578,22 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
 
     const tileset = await Cesium3DTileset.fromUrl(resource, {
       show: true,
+      backFaceCulling: false,
+
+      // This feature flag has major performance implications. We turn it off so that large tilesets are performant.
+      enableCollision: false,
+
+      maximumScreenSpaceError: 16,
+      cullWithChildrenBounds: true,
+      cullRequestsWhileMoving: true,
+      cullRequestsWhileMovingMultiplier: 100,
+      preloadWhenHidden: false,
+      preferLeaves: true,
+      dynamicScreenSpaceError: true,
+      foveatedScreenSpaceError: true,
+      foveatedConeSize: 0.2,
+      foveatedMinimumScreenSpaceErrorRelaxation: 3,
+      foveatedTimeDelay: 0.2,
     });
 
     tileset.imageBasedLighting = new ImageBasedLighting();
@@ -629,7 +641,11 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
     }
 
     const numbersByAxis = this.resolveNumbersByAxis(selection);
-    const updates: Array<Promise<void>> = [];
+    // Track, per axis, whether *this* call's own selection is the one that
+    // ended up active — an axis whose update was superseded by a later
+    // selection before/while being applied must not have its (now stale)
+    // neighbourhood prioritized/warmed below.
+    const isAxisSelectionActive = new Map<SeismicSliceAxis, Promise<boolean>>();
 
     for (const axis of SEISMIC_SLICE_AXES) {
       const slot = this.axisSlots.get(axis);
@@ -647,7 +663,8 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
         slot.clear();
         continue;
       }
-      updates.push(
+      isAxisSelectionActive.set(
+        axis,
         slot.setSlices(
           this.originalTilesetJson,
           this.baseUrl,
@@ -658,9 +675,13 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
       );
     }
 
-    await Promise.all(updates);
+    await Promise.all(isAxisSelectionActive.values());
     if (selection.mode === 'single') {
       for (const axis of SEISMIC_SLICE_AXES) {
+        const isActive = await (isAxisSelectionActive.get(axis) ?? true);
+        if (!isActive) {
+          continue;
+        }
         const center = selection.single[axis];
         this.prioritizeAxisNeighborhood(axis, center);
         this.warmAxisNeighborhood(axis, center);

--- a/ui/src/features/layer/controllers/layer-tiles3d.controller.ts
+++ b/ui/src/features/layer/controllers/layer-tiles3d.controller.ts
@@ -657,21 +657,34 @@ export class Tiles3dLayerController extends BaseLayerController<Tiles3dLayer> {
       if (this.appliedNumbersByAxis.get(axis) === numbersKey) {
         continue;
       }
-      this.appliedNumbersByAxis.set(axis, numbersKey);
 
       if (numbers.length === 0) {
+        // `clear()` is synchronous and cannot fail, so it is safe to record
+        // immediately.
+        this.appliedNumbersByAxis.set(axis, numbersKey);
         slot.clear();
         continue;
       }
       isAxisSelectionActive.set(
         axis,
-        slot.setSlices(
-          this.originalTilesetJson,
-          this.baseUrl,
-          this.resourceHeaders,
-          AXIS_TO_DIRECTION[axis],
-          numbers,
-        ),
+        slot
+          .setSlices(
+            this.originalTilesetJson,
+            this.baseUrl,
+            this.resourceHeaders,
+            AXIS_TO_DIRECTION[axis],
+            numbers,
+          )
+          .then((isActive) => {
+            // Only record this selection as applied once it has actually
+            // succeeded (and is still the active one) — otherwise a failed
+            // build would permanently block retrying the same numbers, since
+            // the equality check above would keep skipping it.
+            if (isActive) {
+              this.appliedNumbersByAxis.set(axis, numbersKey);
+            }
+            return isActive;
+          }),
       );
     }
 

--- a/ui/src/features/layer/controllers/layer.controller.ts
+++ b/ui/src/features/layer/controllers/layer.controller.ts
@@ -242,22 +242,29 @@ export abstract class BaseLayerController<T extends BaseLayer> {
       );
     }
     this.activeUpdate = process;
-    return new Promise((resolve) =>
-      process.then(() => {
-        resolve();
-        this.activeUpdate = null;
+    return new Promise((resolve, reject) =>
+      process.then(
+        () => {
+          resolve();
+          this.activeUpdate = null;
 
-        if (this.nextUpdate === null) {
-          return;
-        }
+          if (this.nextUpdate === null) {
+            return;
+          }
 
-        const [nextUpdate, callback] = this.nextUpdate;
-        this.nextUpdate = null;
+          const [nextUpdate, callback] = this.nextUpdate;
+          this.nextUpdate = null;
 
-        this.update(nextUpdate).then(() => {
-          callback();
-        });
-      }),
+          this.update(nextUpdate).then(() => {
+            callback();
+          });
+        },
+        (error: unknown) => {
+          this.activeUpdate = null;
+          this.nextUpdate = null;
+          reject(error);
+        },
+      ),
     );
   }
 

--- a/ui/src/features/layer/controllers/layer.controller.ts
+++ b/ui/src/features/layer/controllers/layer.controller.ts
@@ -157,7 +157,7 @@ export abstract class BaseLayerController<T extends BaseLayer> {
    *
    * @private
    */
-  private nextUpdate: [T, () => void, (error: unknown) => void] | null = null;
+  private nextUpdate: [T, () => void] | null = null;
 
   constructor(
     /**
@@ -215,25 +215,21 @@ export abstract class BaseLayerController<T extends BaseLayer> {
 
     // If there is no queued update, we can take that spot.
     if (this.nextUpdate === null) {
-      return new Promise((resolve, reject) => {
-        this.nextUpdate = [layer, resolve, reject];
+      return new Promise((resolve) => {
+        this.nextUpdate = [layer, resolve];
       });
     }
 
     // There is already a queued update.
     // We replace that queued value with our own (which is safe as we have a full copy of the layer data).
     // It's important that we preserve all queued callbacks and run them after the update.
-    const [_previousUpdate, previousCallback, previousReject] = this.nextUpdate;
-    return new Promise((resolve, reject) => {
+    const [_previousUpdate, previousCallback] = this.nextUpdate;
+    return new Promise((resolve) => {
       this.nextUpdate = [
         layer,
         () => {
           previousCallback();
           resolve();
-        },
-        (error: unknown) => {
-          previousReject(error);
-          reject(error);
         },
       ];
     });
@@ -246,36 +242,22 @@ export abstract class BaseLayerController<T extends BaseLayer> {
       );
     }
     this.activeUpdate = process;
-    return new Promise((resolve, reject) =>
-      process.then(
-        () => {
-          resolve();
-          this.activeUpdate = null;
+    return new Promise((resolve) =>
+      process.then(() => {
+        resolve();
+        this.activeUpdate = null;
 
-          if (this.nextUpdate === null) {
-            return;
-          }
+        if (this.nextUpdate === null) {
+          return;
+        }
 
-          const [nextUpdate, callback, rejectCallback] = this.nextUpdate;
-          this.nextUpdate = null;
+        const [nextUpdate, callback] = this.nextUpdate;
+        this.nextUpdate = null;
 
-          this.update(nextUpdate).then(
-            () => {
-              callback();
-            },
-            (error: unknown) => {
-              rejectCallback(error);
-            },
-          );
-        },
-        (error: unknown) => {
-          this.activeUpdate = null;
-          const queued = this.nextUpdate;
-          this.nextUpdate = null;
-          queued?.[2](error);
-          reject(error);
-        },
-      ),
+        this.update(nextUpdate).then(() => {
+          callback();
+        });
+      }),
     );
   }
 

--- a/ui/src/features/layer/controllers/layer.controller.ts
+++ b/ui/src/features/layer/controllers/layer.controller.ts
@@ -157,7 +157,7 @@ export abstract class BaseLayerController<T extends BaseLayer> {
    *
    * @private
    */
-  private nextUpdate: [T, () => void] | null = null;
+  private nextUpdate: [T, () => void, (error: unknown) => void] | null = null;
 
   constructor(
     /**
@@ -215,21 +215,25 @@ export abstract class BaseLayerController<T extends BaseLayer> {
 
     // If there is no queued update, we can take that spot.
     if (this.nextUpdate === null) {
-      return new Promise((resolve) => {
-        this.nextUpdate = [layer, resolve];
+      return new Promise((resolve, reject) => {
+        this.nextUpdate = [layer, resolve, reject];
       });
     }
 
     // There is already a queued update.
     // We replace that queued value with our own (which is safe as we have a full copy of the layer data).
     // It's important that we preserve all queued callbacks and run them after the update.
-    const [_previousUpdate, previousCallback] = this.nextUpdate;
-    return new Promise((resolve) => {
+    const [_previousUpdate, previousCallback, previousReject] = this.nextUpdate;
+    return new Promise((resolve, reject) => {
       this.nextUpdate = [
         layer,
         () => {
           previousCallback();
           resolve();
+        },
+        (error: unknown) => {
+          previousReject(error);
+          reject(error);
         },
       ];
     });
@@ -252,16 +256,23 @@ export abstract class BaseLayerController<T extends BaseLayer> {
             return;
           }
 
-          const [nextUpdate, callback] = this.nextUpdate;
+          const [nextUpdate, callback, rejectCallback] = this.nextUpdate;
           this.nextUpdate = null;
 
-          this.update(nextUpdate).then(() => {
-            callback();
-          });
+          this.update(nextUpdate).then(
+            () => {
+              callback();
+            },
+            (error: unknown) => {
+              rejectCallback(error);
+            },
+          );
         },
         (error: unknown) => {
           this.activeUpdate = null;
+          const queued = this.nextUpdate;
           this.nextUpdate = null;
+          queued?.[2](error);
           reject(error);
         },
       ),

--- a/ui/src/features/layer/controllers/layer.controller.ts
+++ b/ui/src/features/layer/controllers/layer.controller.ts
@@ -157,7 +157,7 @@ export abstract class BaseLayerController<T extends BaseLayer> {
    *
    * @private
    */
-  private nextUpdate: [T, () => void] | null = null;
+  private nextUpdate: [T, () => void, (error: unknown) => void] | null = null;
 
   constructor(
     /**
@@ -215,21 +215,25 @@ export abstract class BaseLayerController<T extends BaseLayer> {
 
     // If there is no queued update, we can take that spot.
     if (this.nextUpdate === null) {
-      return new Promise((resolve) => {
-        this.nextUpdate = [layer, resolve];
+      return new Promise((resolve, reject) => {
+        this.nextUpdate = [layer, resolve, reject];
       });
     }
 
     // There is already a queued update.
     // We replace that queued value with our own (which is safe as we have a full copy of the layer data).
     // It's important that we preserve all queued callbacks and run them after the update.
-    const [_previousUpdate, previousCallback] = this.nextUpdate;
-    return new Promise((resolve) => {
+    const [_previousUpdate, previousCallback, previousReject] = this.nextUpdate;
+    return new Promise((resolve, reject) => {
       this.nextUpdate = [
         layer,
         () => {
           previousCallback();
           resolve();
+        },
+        (error: unknown) => {
+          previousReject(error);
+          reject(error);
         },
       ];
     });
@@ -242,22 +246,36 @@ export abstract class BaseLayerController<T extends BaseLayer> {
       );
     }
     this.activeUpdate = process;
-    return new Promise((resolve) =>
-      process.then(() => {
-        resolve();
-        this.activeUpdate = null;
+    return new Promise((resolve, reject) =>
+      process.then(
+        () => {
+          resolve();
+          this.activeUpdate = null;
 
-        if (this.nextUpdate === null) {
-          return;
-        }
+          if (this.nextUpdate === null) {
+            return;
+          }
 
-        const [nextUpdate, callback] = this.nextUpdate;
-        this.nextUpdate = null;
+          const [nextUpdate, callback, rejectCallback] = this.nextUpdate;
+          this.nextUpdate = null;
 
-        this.update(nextUpdate).then(() => {
-          callback();
-        });
-      }),
+          this.update(nextUpdate).then(
+            () => {
+              callback();
+            },
+            (error: unknown) => {
+              rejectCallback(error);
+            },
+          );
+        },
+        (error: unknown) => {
+          this.activeUpdate = null;
+          const queued = this.nextUpdate;
+          this.nextUpdate = null;
+          queued?.[2](error);
+          reject(error);
+        },
+      ),
     );
   }
 

--- a/ui/src/features/layer/controllers/layer.geojson.controller.ts
+++ b/ui/src/features/layer/controllers/layer.geojson.controller.ts
@@ -325,6 +325,7 @@ export class GeoJsonLayerController extends BaseLayerController<GeoJsonLayer> {
       orderOfProperties: [],
       customProperties: {},
       isPartiallyTransparent: false,
+      sliceSelection: null,
     };
   }
 

--- a/ui/src/features/layer/index.ts
+++ b/ui/src/features/layer/index.ts
@@ -8,6 +8,8 @@ export * from './controllers/layer-voxel.controller';
 export * from './controllers/layer-wmts.controller';
 export * from './controllers/layer.geojson.controller';
 
+export * from './slice';
+
 export * from './layer.service';
 export * from './layer-api.service';
 export * from './layer-url.service';

--- a/ui/src/features/layer/info/pickers/layer-drill-picker.ts
+++ b/ui/src/features/layer/info/pickers/layer-drill-picker.ts
@@ -68,8 +68,7 @@ export abstract class LayerInfoDrillPicker<
     }
 
     const tileset = (feature as any).content?._tileset as
-      | Cesium3DTileset
-      | undefined;
+      Cesium3DTileset | undefined;
     if (tileset !== undefined && 'metadata' in tileset) {
       return this.pickFeatureForNewTileset(pick, tileset);
     }

--- a/ui/src/features/layer/info/pickers/layer-drill-picker.ts
+++ b/ui/src/features/layer/info/pickers/layer-drill-picker.ts
@@ -68,7 +68,8 @@ export abstract class LayerInfoDrillPicker<
     }
 
     const tileset = (feature as any).content?._tileset as
-      Cesium3DTileset | undefined;
+      | Cesium3DTileset
+      | undefined;
     if (tileset !== undefined && 'metadata' in tileset) {
       return this.pickFeatureForNewTileset(pick, tileset);
     }

--- a/ui/src/features/layer/info/pickers/layer-info-picker-for-wmts.service.ts
+++ b/ui/src/features/layer/info/pickers/layer-info-picker-for-wmts.service.ts
@@ -15,14 +15,6 @@ const FEATURE_INFO_WIDTH = 101;
 const FEATURE_INFO_HEIGHT = 101;
 const FEATURE_INFO_BBOX_DELTA = 5;
 const URL_PATTERN = /^https?:\/\//i;
-/**
- * geo.admin.ch's identify/htmlPopup/WMS endpoints occasionally hang or take
- * a very long time to respond (observed as slow gateway timeouts). Without a
- * bound, a single slow/unresponsive request can stall the entire info-box
- * pick (see `LayerInfoService.handlePick`, which awaits every layer's pick
- * before showing any results) for far longer than is useful.
- */
-const FEATURE_INFO_FETCH_TIMEOUT_MS = 6_000;
 
 const WMTS_ENDPOINT_SUFFIXES = [
   '/gwc/service/wmts',
@@ -143,9 +135,7 @@ class GeoAdminWmtsInfoClient {
         baseUrl,
       );
       try {
-        const response = await fetch(identifyUrl, {
-          signal: AbortSignal.timeout(FEATURE_INFO_FETCH_TIMEOUT_MS),
-        });
+        const response = await fetch(identifyUrl);
         if (!response.ok) {
           continue;
         }
@@ -171,9 +161,7 @@ class GeoAdminWmtsInfoClient {
     for (const baseUrl of this.buildRestApiBaseUrls()) {
       const popupUrl = this.buildHtmlPopupUrl(result, lang, baseUrl);
       try {
-        const response = await fetch(popupUrl, {
-          signal: AbortSignal.timeout(FEATURE_INFO_FETCH_TIMEOUT_MS),
-        });
+        const response = await fetch(popupUrl);
         if (!response.ok) {
           continue;
         }
@@ -343,9 +331,7 @@ class ExternalWmtsInfoClient {
     }
 
     try {
-      const response = await fetch(infoUrl, {
-        signal: AbortSignal.timeout(FEATURE_INFO_FETCH_TIMEOUT_MS),
-      });
+      const response = await fetch(infoUrl);
       if (!response.ok) {
         return null;
       }

--- a/ui/src/features/layer/info/pickers/layer-info-picker-for-wmts.service.ts
+++ b/ui/src/features/layer/info/pickers/layer-info-picker-for-wmts.service.ts
@@ -15,6 +15,14 @@ const FEATURE_INFO_WIDTH = 101;
 const FEATURE_INFO_HEIGHT = 101;
 const FEATURE_INFO_BBOX_DELTA = 5;
 const URL_PATTERN = /^https?:\/\//i;
+/**
+ * geo.admin.ch's identify/htmlPopup/WMS endpoints occasionally hang or take
+ * a very long time to respond (observed as slow gateway timeouts). Without a
+ * bound, a single slow/unresponsive request can stall the entire info-box
+ * pick (see `LayerInfoService.handlePick`, which awaits every layer's pick
+ * before showing any results) for far longer than is useful.
+ */
+const FEATURE_INFO_FETCH_TIMEOUT_MS = 6_000;
 
 const WMTS_ENDPOINT_SUFFIXES = [
   '/gwc/service/wmts',
@@ -135,7 +143,9 @@ class GeoAdminWmtsInfoClient {
         baseUrl,
       );
       try {
-        const response = await fetch(identifyUrl);
+        const response = await fetch(identifyUrl, {
+          signal: AbortSignal.timeout(FEATURE_INFO_FETCH_TIMEOUT_MS),
+        });
         if (!response.ok) {
           continue;
         }
@@ -161,7 +171,9 @@ class GeoAdminWmtsInfoClient {
     for (const baseUrl of this.buildRestApiBaseUrls()) {
       const popupUrl = this.buildHtmlPopupUrl(result, lang, baseUrl);
       try {
-        const response = await fetch(popupUrl);
+        const response = await fetch(popupUrl, {
+          signal: AbortSignal.timeout(FEATURE_INFO_FETCH_TIMEOUT_MS),
+        });
         if (!response.ok) {
           continue;
         }
@@ -331,7 +343,9 @@ class ExternalWmtsInfoClient {
     }
 
     try {
-      const response = await fetch(infoUrl);
+      const response = await fetch(infoUrl, {
+        signal: AbortSignal.timeout(FEATURE_INFO_FETCH_TIMEOUT_MS),
+      });
       if (!response.ok) {
         return null;
       }

--- a/ui/src/features/layer/info/pickers/layer-info-picker-for-wmts.ts
+++ b/ui/src/features/layer/info/pickers/layer-info-picker-for-wmts.ts
@@ -55,6 +55,15 @@ export class LayerInfoPickerForWmts implements LayerInfoPicker {
     if (!this.controller.layer.isVisible) {
       return [];
     }
+    // When the camera is underground, the map/basemap surface generally
+    // isn't what's actually under the cursor (e.g. an underground slice), and
+    // the picked position (see `PickService.pickWithMath`'s ellipsoid
+    // fallback for rays that miss the terrain) is a rough approximation, not
+    // a real point on the ground. Querying geo.admin's identify service for
+    // it would be both meaningless and slow (or fail outright), so skip it.
+    if (this.viewer.scene.cameraUnderground) {
+      return [];
+    }
 
     // Flow:
     // 1) Try geo.admin identify/htmlPopup when supported.

--- a/ui/src/features/layer/info/pickers/layer-info-picker-for-wmts.ts
+++ b/ui/src/features/layer/info/pickers/layer-info-picker-for-wmts.ts
@@ -55,15 +55,6 @@ export class LayerInfoPickerForWmts implements LayerInfoPicker {
     if (!this.controller.layer.isVisible) {
       return [];
     }
-    // When the camera is underground, the map/basemap surface generally
-    // isn't what's actually under the cursor (e.g. an underground slice), and
-    // the picked position (see `PickService.pickWithMath`'s ellipsoid
-    // fallback for rays that miss the terrain) is a rough approximation, not
-    // a real point on the ground. Querying geo.admin's identify service for
-    // it would be both meaningless and slow (or fail outright), so skip it.
-    if (this.viewer.scene.cameraUnderground) {
-      return [];
-    }
 
     // Flow:
     // 1) Try geo.admin identify/htmlPopup when supported.

--- a/ui/src/features/layer/layer-api.service.ts
+++ b/ui/src/features/layer/layer-api.service.ts
@@ -254,6 +254,7 @@ export class LayerApiService extends BaseService {
     orderOfProperties: config.takeNullable('orderOfProperties') ?? [],
     source: config.takeObject('source').apply(this.mapConfigToSource),
     isPartiallyTransparent: false,
+    sliceSelection: null,
   });
 
   private readonly mapConfigToVoxelLayer = (

--- a/ui/src/features/layer/layer.service.ts
+++ b/ui/src/features/layer/layer.service.ts
@@ -184,13 +184,17 @@ export class LayerService extends BaseService {
     });
 
     // Load (and reload) the layers whenever the session changes.
+    // Wait for LayerApiService too — otherwise a fast session init can call
+    // loadLayers() before the API client is injected (race → no catalog/layers).
     SessionService.inject$()
       .pipe(
         switchMap((service) =>
           service.initialized$.pipe(switchMap(() => service.user$)),
         ),
       )
-      .subscribe(() => this.loadLayers());
+      .subscribe(() => {
+        void this.loadLayers();
+      });
 
     // Propagate changes in the WMTS layers to our local state.
     // This mostly happens due to language changes.
@@ -250,6 +254,9 @@ export class LayerService extends BaseService {
    * @private
    */
   private async loadLayers() {
+    // Session init can outrun LayerApiService.inject() on cold start.
+    this.layerApiService ??= await LayerApiService.inject();
+
     /**
      * Inserts a new layer into the local state.
      *
@@ -659,9 +666,14 @@ export class LayerService extends BaseService {
 
     // Create a controller for the layer and add it to the viewer.
     entry.controller = this.makeController(value);
-    entry.controller.add().then(() => {
-      this.viewer.scene.requestRender();
-    });
+    entry.controller.add().then(
+      () => {
+        this.viewer.scene.requestRender();
+      },
+      (error: unknown) => {
+        console.error(`Failed to add layer to viewer: ${layerId}`, error);
+      },
+    );
 
     // Publish the new state.
     entry.state$.next(value);

--- a/ui/src/features/layer/layer.service.ts
+++ b/ui/src/features/layer/layer.service.ts
@@ -184,17 +184,13 @@ export class LayerService extends BaseService {
     });
 
     // Load (and reload) the layers whenever the session changes.
-    // Wait for LayerApiService too — otherwise a fast session init can call
-    // loadLayers() before the API client is injected (race → no catalog/layers).
     SessionService.inject$()
       .pipe(
         switchMap((service) =>
           service.initialized$.pipe(switchMap(() => service.user$)),
         ),
       )
-      .subscribe(() => {
-        void this.loadLayers();
-      });
+      .subscribe(() => this.loadLayers());
 
     // Propagate changes in the WMTS layers to our local state.
     // This mostly happens due to language changes.
@@ -254,9 +250,6 @@ export class LayerService extends BaseService {
    * @private
    */
   private async loadLayers() {
-    // Session init can outrun LayerApiService.inject() on cold start.
-    this.layerApiService ??= await LayerApiService.inject();
-
     /**
      * Inserts a new layer into the local state.
      *
@@ -666,14 +659,9 @@ export class LayerService extends BaseService {
 
     // Create a controller for the layer and add it to the viewer.
     entry.controller = this.makeController(value);
-    entry.controller.add().then(
-      () => {
-        this.viewer.scene.requestRender();
-      },
-      (error: unknown) => {
-        console.error(`Failed to add layer to viewer: ${layerId}`, error);
-      },
-    );
+    entry.controller.add().then(() => {
+      this.viewer.scene.requestRender();
+    });
 
     // Publish the new state.
     entry.state$.next(value);

--- a/ui/src/features/layer/layer.service.ts
+++ b/ui/src/features/layer/layer.service.ts
@@ -283,7 +283,9 @@ export class LayerService extends BaseService {
           state$: previousLayer.state$,
         };
         this.layers.set(layer.id, updated);
-        updated.controller?.update(layer);
+        updated.controller?.update(layer).catch((error: unknown) => {
+          console.error(`Failed to update layer: ${layer.id}`, error);
+        });
         updated.state$.next(layer);
       }
     };
@@ -419,14 +421,19 @@ export class LayerService extends BaseService {
       };
 
       // Update the existing background controller and add it to the viewer.
-      await this._background.controller.update(layer);
-      await this._background.controller.add();
+      try {
+        await this._background.controller.update(layer);
+        await this._background.controller.add();
 
-      // Publish the new background state.
-      this._background.state$.next(layer);
-
-      // Mark the layers as loaded.
-      this.hasLayers$.next(true);
+        // Publish the new background state.
+        this._background.state$.next(layer);
+      } catch (error) {
+        console.error('Failed to initialize background layer', error);
+      } finally {
+        // Mark the layers as loaded, even if the background failed to
+        // initialize, so that the rest of the app isn't stuck waiting forever.
+        this.hasLayers$.next(true);
+      }
     });
   }
 
@@ -845,9 +852,14 @@ export class LayerService extends BaseService {
     // Apply the update to the controller.
     (entry.controller as BaseLayerController<AnyLayer> | null)
       ?.update(updatedLayer)
-      .then(() => {
-        this.viewer.scene.requestRender();
-      });
+      .then(
+        () => {
+          this.viewer.scene.requestRender();
+        },
+        (error: unknown) => {
+          console.error(`Failed to update layer: ${String(id)}`, error);
+        },
+      );
 
     // Publish the new state.
     (entry.state$ as BehaviorSubject<AnyLayer>).next(updatedLayer);

--- a/ui/src/features/layer/models/layer-tiles3d.model.ts
+++ b/ui/src/features/layer/models/layer-tiles3d.model.ts
@@ -1,4 +1,5 @@
 import { BaseLayer, LayerSource, LayerType } from 'src/features/layer';
+import { Tiles3dSliceSelection } from 'src/features/layer/slice';
 
 export interface Tiles3dLayer extends BaseLayer {
   type: LayerType.Tiles3d;
@@ -19,4 +20,10 @@ export interface Tiles3dLayer extends BaseLayer {
    * For partially transparent tiles, fragments that are fully white are discarded.
    */
   isPartiallyTransparent: boolean;
+
+  /**
+   * Slice selection for OGC 3D seismic volumes.
+   * `null` when the layer does not support slices or metadata is not loaded yet.
+   */
+  sliceSelection: Tiles3dSliceSelection | null;
 }

--- a/ui/src/features/layer/slice/axis-tileset-slot.test.ts
+++ b/ui/src/features/layer/slice/axis-tileset-slot.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 // tilesLoaded, customShader).
 class FakeEvent {
   private readonly listeners: Array<(...args: unknown[]) => void> = [];
+
   addEventListener(callback: (...args: unknown[]) => void): () => void {
     this.listeners.push(callback);
     return () => {
@@ -17,6 +18,7 @@ class FakeEvent {
       }
     };
   }
+
   raise(...args: unknown[]): void {
     for (const listener of [...this.listeners]) {
       listener(...args);
@@ -59,9 +61,11 @@ class FakeCesium3DTileset {
 class FakeCustomShader {
   setUniform = vi.fn();
   private destroyed = false;
+
   isDestroyed(): boolean {
     return this.destroyed;
   }
+
   destroy(): void {
     this.destroyed = true;
   }
@@ -132,9 +136,13 @@ describe('AxisTilesetSlot', () => {
   it('builds and reveals a tileset for a new selection', async () => {
     const { slot, viewer } = makeSlot();
 
-    const isActive = await slot.setSlices({}, 'https://x/tileset.json', {}, 'u', [
-      3,
-    ]);
+    const isActive = await slot.setSlices(
+      {},
+      'https://x/tileset.json',
+      {},
+      'u',
+      [3],
+    );
 
     expect(isActive).toBe(true);
     expect(slot.currentTileset).not.toBeNull();
@@ -153,7 +161,7 @@ describe('AxisTilesetSlot', () => {
     expect(slot.currentTileset).toBe(first);
   });
 
-  it("resolves false for a queued call that is superseded before it is applied", async () => {
+  it('resolves false for a queued call that is superseded before it is applied', async () => {
     const { slot } = makeSlot();
 
     // Make the first build hang so the second call queues behind it.
@@ -165,9 +173,13 @@ describe('AxisTilesetSlot', () => {
         }),
     );
 
-    const firstCall = slot.setSlices({}, 'https://x/tileset.json', {}, 'u', [
-      1,
-    ]);
+    const firstCall = slot.setSlices(
+      {},
+      'https://x/tileset.json',
+      {},
+      'u',
+      [1],
+    );
     // Both of these queue behind the in-flight first call and are collapsed
     // into a single `pending` slot — only the last (numbers=[3]) is ever
     // actually applied.
@@ -178,9 +190,13 @@ describe('AxisTilesetSlot', () => {
       'u',
       [2],
     );
-    const winningCall = slot.setSlices({}, 'https://x/tileset.json', {}, 'u', [
-      3,
-    ]);
+    const winningCall = slot.setSlices(
+      {},
+      'https://x/tileset.json',
+      {},
+      'u',
+      [3],
+    );
 
     resolveFirstBuild(new FakeCesium3DTileset({ show: false }));
 
@@ -254,9 +270,13 @@ describe('AxisTilesetSlot', () => {
     // Warming the same slice must not just wave it through because a cache
     // entry exists: it must still wait for it to actually finish loading.
     FakeCesium3DTileset.fromUrl.mockClear();
-    const warmPromise = slot.warmSlices({}, 'https://x/tileset.json', {}, 'u', [
-      7,
-    ]);
+    const warmPromise = slot.warmSlices(
+      {},
+      'https://x/tileset.json',
+      {},
+      'u',
+      [7],
+    );
     // It must not have rebuilt/re-requested a second tileset for the same
     // key — it should be joining the existing cache entry instead.
     expect(FakeCesium3DTileset.fromUrl).not.toHaveBeenCalled();

--- a/ui/src/features/layer/slice/axis-tileset-slot.test.ts
+++ b/ui/src/features/layer/slice/axis-tileset-slot.test.ts
@@ -1,0 +1,271 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// `axis-tileset-slot.ts` builds real Cesium3DTileset instances. Unit-testing
+// its scheduling/caching/generation logic does not need real Cesium GPU
+// resources, so we replace the module with lightweight fakes that mimic
+// just the surface AxisTilesetSlot touches (events, isDestroyed/destroy,
+// tilesLoaded, customShader).
+class FakeEvent {
+  private readonly listeners: Array<(...args: unknown[]) => void> = [];
+  addEventListener(callback: (...args: unknown[]) => void): () => void {
+    this.listeners.push(callback);
+    return () => {
+      const index = this.listeners.indexOf(callback);
+      if (index >= 0) {
+        this.listeners.splice(index, 1);
+      }
+    };
+  }
+  raise(...args: unknown[]): void {
+    for (const listener of [...this.listeners]) {
+      listener(...args);
+    }
+  }
+}
+
+class FakeCesium3DTileset {
+  static fromUrl = vi.fn(
+    async (
+      _resource: unknown,
+      options: Record<string, unknown>,
+    ): Promise<FakeCesium3DTileset> => new FakeCesium3DTileset(options),
+  );
+
+  show: boolean;
+  preloadWhenHidden: boolean;
+  customShader: unknown = null;
+  /** Tests set this directly to control `waitUntilReady`'s fast path. */
+  tilesLoaded = true;
+  environmentMapManager = { enabled: true };
+  imageBasedLighting: unknown = null;
+  readonly loadProgress = new FakeEvent();
+  private destroyed = false;
+
+  constructor(options: Record<string, unknown>) {
+    this.show = Boolean(options.show);
+    this.preloadWhenHidden = Boolean(options.preloadWhenHidden);
+  }
+
+  isDestroyed(): boolean {
+    return this.destroyed;
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+  }
+}
+
+class FakeCustomShader {
+  setUniform = vi.fn();
+  private destroyed = false;
+  isDestroyed(): boolean {
+    return this.destroyed;
+  }
+  destroy(): void {
+    this.destroyed = true;
+  }
+}
+
+vi.mock('cesium', () => ({
+  Cesium3DTileset: FakeCesium3DTileset,
+  CustomShader: FakeCustomShader,
+  ImageBasedLighting: class ImageBasedLighting {
+    imageBasedLightingFactor: unknown;
+  },
+  Cartesian2: class Cartesian2 {
+    constructor(
+      public x: number,
+      public y: number,
+    ) {}
+  },
+  Resource: class Resource {},
+}));
+
+vi.mock('src/services/pick.service', () => {
+  class FakePickService {
+    static get = vi.fn(() => new FakePickService());
+    acquireScenePickingLock = vi.fn(() => ({ release: vi.fn() }));
+  }
+  return { PickService: FakePickService };
+});
+
+vi.mock('src/features/layer/slice/tileset-slice-prune', () => ({
+  pruneTilesetToSlices: vi.fn((json: unknown) => json),
+  toBlobUrl: vi.fn(() => `blob:fake-${Math.random()}`),
+  createAuthenticatedBlobResource: vi.fn((blobUrl: string) => ({
+    url: blobUrl,
+  })),
+}));
+
+const { AxisTilesetSlot } = await import('./axis-tileset-slot');
+
+const makeViewer = () => ({
+  scene: {
+    primitives: {
+      add: vi.fn(),
+      remove: vi.fn(),
+      raiseToTop: vi.fn(),
+    },
+    requestRender: vi.fn(),
+  },
+});
+
+const makeSlot = () => {
+  const viewer = makeViewer();
+  const slot = new AxisTilesetSlot({
+    // Only the `scene` surface above is touched by AxisTilesetSlot.
+    viewer: viewer as never,
+    makeShader: () => new FakeCustomShader() as never,
+    getOpacity: () => 1,
+    getVisibility: () => true,
+  });
+  return { slot, viewer };
+};
+
+describe('AxisTilesetSlot', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('builds and reveals a tileset for a new selection', async () => {
+    const { slot, viewer } = makeSlot();
+
+    const isActive = await slot.setSlices({}, 'https://x/tileset.json', {}, 'u', [
+      3,
+    ]);
+
+    expect(isActive).toBe(true);
+    expect(slot.currentTileset).not.toBeNull();
+    expect(slot.currentTileset?.show).toBe(true);
+    expect(viewer.scene.primitives.add).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses the cached tileset when the same slice is requested again', async () => {
+    const { slot } = makeSlot();
+
+    await slot.setSlices({}, 'https://x/tileset.json', {}, 'u', [3]);
+    const first = slot.currentTileset;
+    await slot.setSlices({}, 'https://x/tileset.json', {}, 'u', [5]);
+    await slot.setSlices({}, 'https://x/tileset.json', {}, 'u', [3]);
+
+    expect(slot.currentTileset).toBe(first);
+  });
+
+  it("resolves false for a queued call that is superseded before it is applied", async () => {
+    const { slot } = makeSlot();
+
+    // Make the first build hang so the second call queues behind it.
+    let resolveFirstBuild!: (tileset: FakeCesium3DTileset) => void;
+    FakeCesium3DTileset.fromUrl.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirstBuild = (tileset) => resolve(tileset);
+        }),
+    );
+
+    const firstCall = slot.setSlices({}, 'https://x/tileset.json', {}, 'u', [
+      1,
+    ]);
+    // Both of these queue behind the in-flight first call and are collapsed
+    // into a single `pending` slot — only the last (numbers=[3]) is ever
+    // actually applied.
+    const supersededCall = slot.setSlices(
+      {},
+      'https://x/tileset.json',
+      {},
+      'u',
+      [2],
+    );
+    const winningCall = slot.setSlices({}, 'https://x/tileset.json', {}, 'u', [
+      3,
+    ]);
+
+    resolveFirstBuild(new FakeCesium3DTileset({ show: false }));
+
+    const [isFirstActive, isSupersededActive, isWinningActive] =
+      await Promise.all([firstCall, supersededCall, winningCall]);
+
+    // Only the numbers=[3] selection is ever actually applied (queued calls
+    // collapse into a single `pending` slot) — the first call itself
+    // resolves once *all* queued updates (including the later, winning one)
+    // have drained, so its own selection ([1]) is correctly reported as no
+    // longer active either.
+    expect(isFirstActive).toBe(false);
+    expect(isSupersededActive).toBe(false);
+    expect(isWinningActive).toBe(true);
+    expect(slot.currentTileset).not.toBeNull();
+  });
+
+  it('clear() hides the active tileset and stops in-flight warming', async () => {
+    const { slot } = makeSlot();
+    await slot.setSlices({}, 'https://x/tileset.json', {}, 'u', [1]);
+    const tileset = slot.currentTileset;
+    expect(tileset).not.toBeNull();
+
+    slot.clear();
+
+    expect(slot.currentTileset).toBeNull();
+    expect(tileset?.show).toBe(false);
+
+    // A subsequent warmSlices() call for the same axis must observe the
+    // generation bump and stop before building anything further.
+    FakeCesium3DTileset.fromUrl.mockClear();
+    await slot.warmSlices({}, 'https://x/tileset.json', {}, 'u', [1, 2]);
+    // warmSlices captures its own generation at the start of the call, so a
+    // clear() that already happened *before* the call is not itself a mid-
+    // loop cancellation — this just documents current, correct behaviour:
+    // warming proceeds for a call started after clear() unless superseded
+    // again while running.
+    expect(FakeCesium3DTileset.fromUrl).toHaveBeenCalled();
+  });
+
+  it("warmOneSlice does not fast-path a cached tileset that hasn't finished loading", async () => {
+    vi.useFakeTimers();
+    const { slot } = makeSlot();
+
+    // Build once via the interactive path with tilesLoaded = false, so it
+    // ends up cached but not yet ready — e.g. a swap that was revealed once
+    // its ready-timeout elapsed (see TILESET_READY_TIMEOUT_MS) while content
+    // was still loading.
+    FakeCesium3DTileset.fromUrl.mockImplementationOnce(
+      async (_resource, options: Record<string, unknown>) => {
+        const tileset = new FakeCesium3DTileset(options);
+        tileset.tilesLoaded = false;
+        return tileset;
+      },
+    );
+    const setSlicesPromise = slot.setSlices(
+      {},
+      'https://x/tileset.json',
+      {},
+      'u',
+      [7],
+    );
+    // Let the build resolve, then let waitUntilReady's ready-timeout elapse
+    // so the still-loading tileset gets revealed anyway.
+    await vi.advanceTimersByTimeAsync(3_000);
+    await setSlicesPromise;
+
+    const cachedTileset = slot.currentTileset;
+    expect(cachedTileset?.tilesLoaded).toBe(false);
+
+    // Warming the same slice must not just wave it through because a cache
+    // entry exists: it must still wait for it to actually finish loading.
+    FakeCesium3DTileset.fromUrl.mockClear();
+    const warmPromise = slot.warmSlices({}, 'https://x/tileset.json', {}, 'u', [
+      7,
+    ]);
+    // It must not have rebuilt/re-requested a second tileset for the same
+    // key — it should be joining the existing cache entry instead.
+    expect(FakeCesium3DTileset.fromUrl).not.toHaveBeenCalled();
+
+    // The slice now finishes loading; the next warm pump tick must detect it
+    // and let warming complete instead of only giving up at the (much
+    // later) warm timeout.
+    (cachedTileset as unknown as FakeCesium3DTileset).tilesLoaded = true;
+    await vi.advanceTimersByTimeAsync(100);
+    await warmPromise;
+  });
+});

--- a/ui/src/features/layer/slice/axis-tileset-slot.test.ts
+++ b/ui/src/features/layer/slice/axis-tileset-slot.test.ts
@@ -237,6 +237,53 @@ describe('AxisTilesetSlot', () => {
     expect(FakeCesium3DTileset.fromUrl).toHaveBeenCalled();
   });
 
+  it('clear() during an in-flight load discards a queued pending selection', async () => {
+    const { slot } = makeSlot();
+
+    // Make the first build hang so the second call queues behind it in
+    // `pending`.
+    let resolveFirstBuild!: (tileset: FakeCesium3DTileset) => void;
+    FakeCesium3DTileset.fromUrl.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirstBuild = (tileset) => resolve(tileset);
+        }),
+    );
+
+    const firstCall = slot.setSlices(
+      {},
+      'https://x/tileset.json',
+      {},
+      'u',
+      [1],
+    );
+    // Queues behind the in-flight first call into `pending`.
+    const queuedCall = slot.setSlices(
+      {},
+      'https://x/tileset.json',
+      {},
+      'u',
+      [2],
+    );
+
+    // The axis is cleared (e.g. it became inactive in Multiple mode) while
+    // the first load is still in flight and a selection is queued behind it.
+    slot.clear();
+
+    resolveFirstBuild(new FakeCesium3DTileset({ show: false }));
+
+    const [isFirstActive, isQueuedActive] = await Promise.all([
+      firstCall,
+      queuedCall,
+    ]);
+
+    // Neither call's selection should end up active: `clear()` must win,
+    // and the queued selection must not be silently applied afterwards.
+    expect(isFirstActive).toBe(false);
+    expect(isQueuedActive).toBe(false);
+    expect(slot.currentTileset).toBeNull();
+  });
+
   it("warmOneSlice does not fast-path a cached tileset that hasn't finished loading", async () => {
     vi.useFakeTimers();
     const { slot } = makeSlot();

--- a/ui/src/features/layer/slice/axis-tileset-slot.ts
+++ b/ui/src/features/layer/slice/axis-tileset-slot.ts
@@ -209,55 +209,75 @@ export class AxisTilesetSlot {
       if (generation !== this.warmGeneration) {
         return;
       }
-      const key = `${direction}:${number}`;
-      const existing = this.cache.get(key);
-      if (existing !== undefined && !existing.tileset.isDestroyed()) {
-        continue;
-      }
-      if (this.isUpdating) {
-        // Never compete with a user-driven swap.
-        return;
-      }
-
-      let created: CachedTileset;
-      try {
-        created = await this.buildOrJoinTileset(
-          key,
-          originalJson,
-          baseUrl,
-          headers,
-          direction,
-          [number],
-        );
-      } catch (error) {
-        console.warn(`Failed to warm slice ${direction}:${number}:`, error);
-        continue;
-      }
-
-      if (generation !== this.warmGeneration) {
-        // A newer selection arrived while building. The tileset is already
-        // cached (possibly by/for the interactive path too), so just make
-        // sure it stops traversing rather than destroying it outright.
-        if (
-          this.tileset !== created.tileset &&
-          !created.tileset.isDestroyed()
-        ) {
-          freezeHidden(created.tileset);
-        }
-        return;
-      }
-
-      await this.waitUntilReady(
-        created.tileset,
-        TILESET_WARM_TIMEOUT_MS,
-        WARM_PUMP_INTERVAL_MS,
+      const shouldContinue = await this.warmOneSlice(
+        generation,
+        originalJson,
+        baseUrl,
+        headers,
+        direction,
+        number,
       );
-      // A swap may have revealed this very tileset while we were waiting —
-      // freezing it then would hide the selected plane.
-      if (this.tileset !== created.tileset && !created.tileset.isDestroyed()) {
-        freezeHidden(created.tileset);
+      if (!shouldContinue) {
+        return;
       }
     }
+  }
+
+  /**
+   * Warm a single slice. Returns `true` to continue to the next slice, or
+   * `false` to abort warming entirely (generation superseded or update in
+   * flight).
+   */
+  private async warmOneSlice(
+    generation: number,
+    originalJson: unknown,
+    baseUrl: string,
+    headers: Record<string, string>,
+    direction: OgcSliceDirection,
+    number: number,
+  ): Promise<boolean> {
+    const key = `${direction}:${number}`;
+    const existing = this.cache.get(key);
+    if (existing !== undefined && !existing.tileset.isDestroyed()) {
+      return true;
+    }
+    if (this.isUpdating) {
+      // Never compete with a user-driven swap.
+      return false;
+    }
+
+    let created: CachedTileset;
+    try {
+      created = await this.buildOrJoinTileset(
+        key,
+        originalJson,
+        baseUrl,
+        headers,
+        direction,
+        [number],
+      );
+    } catch (error) {
+      console.warn(`Failed to warm slice ${direction}:${number}:`, error);
+      return true;
+    }
+
+    if (generation !== this.warmGeneration) {
+      // A newer selection arrived while building. The tileset is already
+      // cached (possibly by/for the interactive path too), so just make
+      // sure it stops traversing rather than destroying it outright.
+      freezeHiddenIfNotActive(this.tileset, created.tileset);
+      return false;
+    }
+
+    await this.waitUntilReady(
+      created.tileset,
+      TILESET_WARM_TIMEOUT_MS,
+      WARM_PUMP_INTERVAL_MS,
+    );
+    // A swap may have revealed this very tileset while we were waiting —
+    // freezing it then would hide the selected plane.
+    freezeHiddenIfNotActive(this.tileset, created.tileset);
+    return true;
   }
 
   /**
@@ -376,20 +396,7 @@ export class AxisTilesetSlot {
 
     const cached = this.cache.get(key);
     if (cached !== undefined && !cached.tileset.isDestroyed()) {
-      this.touchCache(key);
-      if (this.isSuperseded(generation)) {
-        return;
-      }
-      if (!cached.tileset.tilesLoaded) {
-        // Frozen cache entries do not traverse; re-enable before waiting.
-        cached.tileset.preloadWhenHidden = true;
-        await this.waitUntilReady(cached.tileset);
-        if (this.isRevealSuperseded(generation)) {
-          freezeHidden(cached.tileset);
-          return;
-        }
-      }
-      this.revealTileset(key, cached.tileset, previous);
+      await this.revealCachedTileset(key, cached, previous, generation);
       return;
     }
 
@@ -429,6 +436,28 @@ export class AxisTilesetSlot {
     }
 
     this.revealTileset(key, tileset, previous);
+  }
+
+  private async revealCachedTileset(
+    key: string,
+    cached: CachedTileset,
+    previous: Cesium3DTileset | null,
+    generation: number,
+  ): Promise<void> {
+    this.touchCache(key);
+    if (this.isSuperseded(generation)) {
+      return;
+    }
+    if (!cached.tileset.tilesLoaded) {
+      // Frozen cache entries do not traverse; re-enable before waiting.
+      cached.tileset.preloadWhenHidden = true;
+      await this.waitUntilReady(cached.tileset);
+      if (this.isRevealSuperseded(generation)) {
+        freezeHidden(cached.tileset);
+        return;
+      }
+    }
+    this.revealTileset(key, cached.tileset, previous);
   }
 
   /**
@@ -758,7 +787,8 @@ export class AxisTilesetSlot {
     this.warmGeneration += 1;
     this.scenePickingLock?.release();
     this.scenePickingLock = null;
-    for (const key of [...this.cache.keys()]) {
+    const keys = Array.from(this.cache.keys());
+    for (const key of keys) {
       this.evictCacheKey(key);
     }
     this.tileset = null;
@@ -782,6 +812,16 @@ const destroyShader = (shader: CustomShader | null): void => {
 const freezeHidden = (tileset: Cesium3DTileset): void => {
   tileset.show = false;
   tileset.preloadWhenHidden = false;
+};
+
+/** Freeze `tileset` only if it is not the currently active one. */
+const freezeHiddenIfNotActive = (
+  active: Cesium3DTileset | null,
+  tileset: Cesium3DTileset,
+): void => {
+  if (active !== tileset && !tileset.isDestroyed()) {
+    freezeHidden(tileset);
+  }
 };
 
 export { TILESET_OPTIONS };

--- a/ui/src/features/layer/slice/axis-tileset-slot.ts
+++ b/ui/src/features/layer/slice/axis-tileset-slot.ts
@@ -50,10 +50,17 @@ const MAX_CACHED_TILESETS = 16;
 
 /**
  * Cap how long we wait for content before revealing anyway.
- * Kept short: showing a partially refined slice beats blocking the swap, and
- * the tileset keeps refining after the reveal.
+ *
+ * The previous slice stays visible for the whole wait (see `revealTileset`),
+ * so there is no "blocking" downside to waiting here — only the upside of
+ * not revealing an empty tileset. Under concurrent load (fast scrubbing plus
+ * background warming on 3 axes), even the very first tile can take well over
+ * a few hundred ms to fetch/parse/upload; a too-short cap made the swap
+ * reveal a completely empty tileset instead of the still-loading previous
+ * one, i.e. a visible blank flash. Kept well below `TILESET_WARM_TIMEOUT_MS`
+ * since this still guards against a genuinely stuck request.
  */
-const TILESET_READY_TIMEOUT_MS = 400;
+const TILESET_READY_TIMEOUT_MS = 3_000;
 
 /**
  * Background warming is off the interaction path, so it may wait much longer.

--- a/ui/src/features/layer/slice/axis-tileset-slot.ts
+++ b/ui/src/features/layer/slice/axis-tileset-slot.ts
@@ -378,6 +378,11 @@ export class AxisTilesetSlot {
     // still-running `warmSlices()` loop keeps requesting/building tilesets
     // for an axis that is no longer shown.
     this.warmGeneration += 1;
+    // Drop any selection queued behind an in-flight load. Without this, the
+    // queue-draining loop in `setSlices()` would still apply it once the
+    // current (now-superseded) load finishes, reactivating this axis right
+    // after `clear()` asked for it to stay hidden.
+    this.pending = null;
     if (this.tileset !== null) {
       freezeHidden(this.tileset);
     }

--- a/ui/src/features/layer/slice/axis-tileset-slot.ts
+++ b/ui/src/features/layer/slice/axis-tileset-slot.ts
@@ -1,0 +1,787 @@
+import {
+  Cartesian2,
+  Cesium3DTileset,
+  CustomShader,
+  ImageBasedLighting,
+  Resource,
+  Viewer,
+} from 'cesium';
+import { PickService, ScenePickingLock } from 'src/services/pick.service';
+import { OgcSliceDirection } from 'src/features/layer/slice/tiles3d-slice.types';
+import {
+  createAuthenticatedBlobResource,
+  pruneTilesetToSlices,
+  toBlobUrl,
+} from 'src/features/layer/slice/tileset-slice-prune';
+
+const TILESET_OPTIONS = {
+  backFaceCulling: false,
+  enableCollision: false,
+  maximumScreenSpaceError: 16,
+  cullWithChildrenBounds: true,
+  cullRequestsWhileMoving: true,
+  cullRequestsWhileMovingMultiplier: 100,
+  // Required for seamless swaps: load the next slice while it is still hidden.
+  preloadWhenHidden: true,
+  preferLeaves: true,
+  // Slice tilesets are a handful of textured quads. The foveated/dynamic SSE
+  // heuristics only defer their requests (foveatedTimeDelay in particular waits
+  // for the camera to settle), which directly delays slider swaps.
+  dynamicScreenSpaceError: false,
+  foveatedScreenSpaceError: false,
+  // Slices are unlit textured quads with a custom shader, so the specular
+  // environment map (a per-tileset cubemap baked over several frames via
+  // deferred ComputeCommands) is both wasted work and actively dangerous
+  // here: we create/destroy dozens of these tilesets in quick succession
+  // (warming/eviction/superseding), and destroying a tileset before its
+  // environment map finishes baking leaves those queued compute commands
+  // writing into an already-deleted texture ("attempt to use a deleted
+  // object" / "Framebuffer is incomplete").
+  environmentMapOptions: { enabled: false },
+} as const;
+
+/**
+ * Keep recently used slice tilesets so scrubbing back is instant.
+ * Must comfortably exceed `SLICE_GPU_WARM_RADIUS * 2` so warming does not
+ * immediately evict its own entries. Each entry holds a decoded slice texture
+ * in GPU memory, so this is a direct VRAM/responsiveness trade-off (× 3 axes).
+ */
+const MAX_CACHED_TILESETS = 16;
+
+/**
+ * Cap how long we wait for content before revealing anyway.
+ * Kept short: showing a partially refined slice beats blocking the swap, and
+ * the tileset keeps refining after the reveal.
+ */
+const TILESET_READY_TIMEOUT_MS = 400;
+
+/**
+ * Background warming is off the interaction path, so it may wait much longer.
+ * Giving up early would leave the slice only partially loaded and defeat the
+ * point of warming it.
+ */
+const TILESET_WARM_TIMEOUT_MS = 30_000;
+
+/**
+ * Warming still needs frames to be rendered for Cesium to traverse a hidden
+ * tileset, but it must not hold the viewer at full frame rate for the whole
+ * warm-up. A slow pump is enough to keep tile requests flowing.
+ */
+const WARM_PUMP_INTERVAL_MS = 100;
+
+export interface AxisTilesetSlotOptions {
+  viewer: Viewer;
+  makeShader: () => CustomShader;
+  getOpacity: () => number;
+  getVisibility: () => boolean;
+}
+
+interface CachedTileset {
+  tileset: Cesium3DTileset;
+  blobUrl: string;
+  /** Releases the scene picking lock held while this tileset loads. */
+  releasePickLock?: () => void;
+}
+
+/**
+ * Owns Cesium3DTilesets for one seismic axis (U / V / W).
+ * Recently used slice selections are kept in an LRU cache so slider scrubbing
+ * does not rebuild the same tileset repeatedly.
+ *
+ * Slice swaps are double-buffered: the previous tileset stays visible until the
+ * next one is ready, then they swap atomically to avoid a blank flash.
+ */
+export class AxisTilesetSlot {
+  private tileset: Cesium3DTileset | null = null;
+  private activeKey: string | null = null;
+  private readonly cache = new Map<string, CachedTileset>();
+  private readonly cacheOrder: string[] = [];
+  private scenePickingLock: ScenePickingLock | null = null;
+  private isUpdating = false;
+  /** Bumped whenever a new selection arrives, cancelling in-flight warming. */
+  private warmGeneration = 0;
+  /** Reused across tilesets so a slice swap does not recompile the shader. */
+  private sharedShader: CustomShader | null = null;
+  private sharedShaderIsOpaque = true;
+  /** Bumped on every setSlices attempt so superseded loads are not revealed. */
+  private loadGeneration = 0;
+  private isDestroyed = false;
+  private pending: {
+    originalJson: unknown;
+    baseUrl: string;
+    headers: Record<string, string>;
+    direction: OgcSliceDirection;
+    numbers: number[];
+  } | null = null;
+  private readonly pendingResolvers: Array<() => void> = [];
+  /**
+   * Tracks tileset builds in progress, keyed the same way as `cache`. Both
+   * the interactive swap path and background warming can want the same slice
+   * at once; without this, both would build and add their own tileset for
+   * that key, and the loser would linger in `scene.primitives` outside the
+   * cache — never re-pointed when the shared shader is later rebuilt, later
+   * crashing an unrelated render with "This object was destroyed".
+   */
+  private readonly inFlightBuilds = new Map<string, Promise<CachedTileset>>();
+
+  constructor(private readonly options: AxisTilesetSlotOptions) {}
+
+  get currentTileset(): Cesium3DTileset | null {
+    return this.tileset;
+  }
+
+  async setSlices(
+    originalJson: unknown,
+    baseUrl: string,
+    headers: Record<string, string>,
+    direction: OgcSliceDirection,
+    numbers: number[],
+  ): Promise<void> {
+    // A new selection wins over any background warming.
+    this.warmGeneration += 1;
+
+    // Fast path: if the target slice is already loaded, swap synchronously.
+    // This must bypass the update queue entirely — otherwise a warmed slice
+    // would still be held back behind an in-flight load of a slice the user
+    // has already scrubbed past.
+    if (this.tryRevealLoaded(direction, numbers)) {
+      return;
+    }
+
+    if (this.isUpdating) {
+      this.pending = { originalJson, baseUrl, headers, direction, numbers };
+      // Resolve only once the queued selection has actually been applied, so
+      // callers do not start warming a neighbourhood that is already stale.
+      return new Promise<void>((resolve) => {
+        this.pendingResolvers.push(resolve);
+      });
+    }
+
+    this.isUpdating = true;
+    try {
+      await this.performSetSlices(
+        originalJson,
+        baseUrl,
+        headers,
+        direction,
+        numbers,
+      );
+      while (this.pending !== null) {
+        const next = this.pending;
+        this.pending = null;
+        await this.performSetSlices(
+          next.originalJson,
+          next.baseUrl,
+          next.headers,
+          next.direction,
+          next.numbers,
+        );
+      }
+    } finally {
+      this.isUpdating = false;
+      for (const resolve of this.pendingResolvers.splice(0)) {
+        resolve();
+      }
+    }
+  }
+
+  /**
+   * Build and fully load hidden tilesets for `numbers` (one slice each) so a
+   * later swap to any of them is a pure `show` flip.
+   *
+   * This is the part that actually makes scrubbing instant: warming only the
+   * HTTP cache still leaves glTF parsing, texture decoding and GPU upload to be
+   * done at swap time, which is the dominant cost.
+   *
+   * Runs one slice at a time, yields between slices, and is cancelled as soon
+   * as a new selection arrives.
+   */
+  async warmSlices(
+    originalJson: unknown,
+    baseUrl: string,
+    headers: Record<string, string>,
+    direction: OgcSliceDirection,
+    numbers: readonly number[],
+  ): Promise<void> {
+    const generation = ++this.warmGeneration;
+
+    for (const number of numbers) {
+      if (generation !== this.warmGeneration) {
+        return;
+      }
+      const key = `${direction}:${number}`;
+      const existing = this.cache.get(key);
+      if (existing !== undefined && !existing.tileset.isDestroyed()) {
+        continue;
+      }
+      if (this.isUpdating) {
+        // Never compete with a user-driven swap.
+        return;
+      }
+
+      let created: CachedTileset;
+      try {
+        created = await this.buildOrJoinTileset(
+          key,
+          originalJson,
+          baseUrl,
+          headers,
+          direction,
+          [number],
+        );
+      } catch (error) {
+        console.warn(`Failed to warm slice ${direction}:${number}:`, error);
+        continue;
+      }
+
+      if (generation !== this.warmGeneration) {
+        // A newer selection arrived while building. The tileset is already
+        // cached (possibly by/for the interactive path too), so just make
+        // sure it stops traversing rather than destroying it outright.
+        if (
+          this.tileset !== created.tileset &&
+          !created.tileset.isDestroyed()
+        ) {
+          freezeHidden(created.tileset);
+        }
+        return;
+      }
+
+      await this.waitUntilReady(
+        created.tileset,
+        TILESET_WARM_TIMEOUT_MS,
+        WARM_PUMP_INTERVAL_MS,
+      );
+      // A swap may have revealed this very tileset while we were waiting —
+      // freezing it then would hide the selected plane.
+      if (this.tileset !== created.tileset && !created.tileset.isDestroyed()) {
+        freezeHidden(created.tileset);
+      }
+    }
+  }
+
+  /**
+   * Synchronously reveal a slice whose tileset is already built and loaded.
+   *
+   * Returns false if the slice still needs loading, in which case the caller
+   * falls back to the queued async path.
+   */
+  private tryRevealLoaded(
+    direction: OgcSliceDirection,
+    numbers: readonly number[],
+  ): boolean {
+    if (numbers.length === 0) {
+      return false;
+    }
+    const key = `${direction}:${numbers.join(',')}`;
+
+    if (
+      key === this.activeKey &&
+      this.tileset !== null &&
+      !this.tileset.isDestroyed()
+    ) {
+      this.supersedeInFlight();
+      this.tileset.show = this.options.getVisibility();
+      this.options.viewer.scene.requestRender();
+      return true;
+    }
+
+    const cached = this.cache.get(key);
+    if (
+      cached === undefined ||
+      cached.tileset.isDestroyed() ||
+      !cached.tileset.tilesLoaded
+    ) {
+      return false;
+    }
+
+    this.supersedeInFlight();
+    this.touchCache(key);
+    this.revealTileset(key, cached.tileset, this.tileset);
+    return true;
+  }
+
+  /**
+   * Invalidate any in-flight or queued load: this selection is newer, and the
+   * slice it wants is already on screen.
+   */
+  private supersedeInFlight(): void {
+    this.loadGeneration += 1;
+    this.pending = null;
+  }
+
+  /** Hide this axis without destroying (used in Multiple mode for inactive axes). */
+  clear(): void {
+    this.loadGeneration += 1;
+    if (this.tileset !== null) {
+      freezeHidden(this.tileset);
+    }
+    this.tileset = null;
+    this.activeKey = null;
+  }
+
+  setOpacity(opacity: number): void {
+    const shader = this.getShader();
+    shader.setUniform('u_alpha', opacity);
+    if (this.tileset !== null && this.tileset.customShader !== shader) {
+      this.tileset.customShader = shader;
+    }
+    this.options.viewer.scene.requestRender();
+  }
+
+  setVisible(isVisible: boolean): void {
+    if (this.tileset === null) {
+      return;
+    }
+    if (isVisible) {
+      this.tileset.preloadWhenHidden = true;
+      this.tileset.show = true;
+    } else {
+      freezeHidden(this.tileset);
+    }
+    this.options.viewer.scene.requestRender();
+  }
+
+  raiseToTop(): void {
+    if (this.tileset !== null) {
+      this.options.viewer.scene.primitives.raiseToTop(this.tileset);
+    }
+  }
+
+  destroy(): void {
+    this.destroyAll();
+  }
+
+  private async performSetSlices(
+    originalJson: unknown,
+    baseUrl: string,
+    headers: Record<string, string>,
+    direction: OgcSliceDirection,
+    numbers: number[],
+  ): Promise<void> {
+    const generation = ++this.loadGeneration;
+
+    if (numbers.length === 0) {
+      this.clear();
+      return;
+    }
+
+    const key = `${direction}:${numbers.join(',')}`;
+    if (key === this.activeKey && this.tileset !== null) {
+      this.tileset.show = this.options.getVisibility();
+      return;
+    }
+
+    const previous = this.tileset;
+
+    const cached = this.cache.get(key);
+    if (cached !== undefined && !cached.tileset.isDestroyed()) {
+      this.touchCache(key);
+      if (this.isSuperseded(generation)) {
+        return;
+      }
+      if (!cached.tileset.tilesLoaded) {
+        // Frozen cache entries do not traverse; re-enable before waiting.
+        cached.tileset.preloadWhenHidden = true;
+        await this.waitUntilReady(cached.tileset);
+        if (this.isRevealSuperseded(generation)) {
+          freezeHidden(cached.tileset);
+          return;
+        }
+      }
+      this.revealTileset(key, cached.tileset, previous);
+      return;
+    }
+
+    let created: CachedTileset;
+    try {
+      created = await this.buildOrJoinTileset(
+        key,
+        originalJson,
+        baseUrl,
+        headers,
+        direction,
+        numbers,
+      );
+    } catch (error) {
+      console.warn(
+        `Failed to build tileset for direction ${direction}:`,
+        error,
+      );
+      if (!this.isSuperseded(generation)) {
+        this.clear();
+      }
+      return;
+    }
+
+    const { tileset } = created;
+    if (this.isSuperseded(generation)) {
+      // Do not reveal, and do not let it keep traversing in the background —
+      // a newer selection already won. It stays cached for later scrubbing.
+      freezeHidden(tileset);
+      return;
+    }
+
+    await this.waitUntilReady(tileset);
+    if (this.isRevealSuperseded(generation)) {
+      freezeHidden(tileset);
+      return;
+    }
+
+    this.revealTileset(key, tileset, previous);
+  }
+
+  /**
+   * Add a freshly built tileset to the scene and the LRU cache, holding a
+   * scene picking lock until its content has loaded.
+   */
+  private addToScene(key: string, entry: CachedTileset): void {
+    this.applyAppearance(entry.tileset);
+    this.options.viewer.scene.primitives.add(entry.tileset);
+    entry.releasePickLock = this.attachPickLock(entry.tileset);
+    this.rememberCache(key, entry);
+  }
+
+  /**
+   * Atomically show the next tileset and hide the previous one.
+   */
+  private revealTileset(
+    key: string,
+    next: Cesium3DTileset,
+    previous: Cesium3DTileset | null,
+  ): void {
+    this.applyAppearance(next);
+    next.preloadWhenHidden = true;
+    next.show = this.options.getVisibility();
+    this.options.viewer.scene.primitives.raiseToTop(next);
+
+    if (previous !== null && previous !== next && !previous.isDestroyed()) {
+      // Stop the demoted tileset from traversing and requesting every frame.
+      // Its already-loaded content stays resident, so scrubbing back is instant.
+      freezeHidden(previous);
+    }
+
+    this.tileset = next;
+    this.activeKey = key;
+    this.options.viewer.scene.requestRender();
+  }
+
+  private isSuperseded(generation: number): boolean {
+    return generation !== this.loadGeneration || this.pending !== null;
+  }
+
+  /**
+   * Whether a finished load should still be revealed.
+   *
+   * Deliberately ignores `pending`: a queued selection means the user is still
+   * scrubbing, and showing this slice is a useful intermediate frame that will
+   * be replaced a moment later. Suppressing it is what made a fast drag look
+   * frozen until the user let go. Only a newer load or a synchronous reveal
+   * (both of which bump `loadGeneration`) cancels the reveal.
+   */
+  private isRevealSuperseded(generation: number): boolean {
+    return generation !== this.loadGeneration;
+  }
+
+  /**
+   * Wait until the tileset has finished its initial content load (or timeout).
+   *
+   * The viewer runs with `requestRenderMode`, and the tileset is added with
+   * `show: false`. Without an explicit render pump, no further frames are
+   * scheduled, the hidden tileset is never traversed, `loadProgress` never
+   * settles and every swap blocks for the full timeout. So we drive a frame per
+   * animation frame until the load settles.
+   */
+  private async waitUntilReady(
+    tileset: Cesium3DTileset,
+    timeoutMs: number = TILESET_READY_TIMEOUT_MS,
+    pumpIntervalMs = 0,
+  ): Promise<void> {
+    if (tileset.tilesLoaded) {
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      let hasSettled = false;
+      let frameId = 0;
+      let pumpTimeoutId = 0;
+
+      const finish = (): void => {
+        if (hasSettled) {
+          return;
+        }
+        hasSettled = true;
+        window.clearTimeout(timeoutId);
+        window.clearTimeout(pumpTimeoutId);
+        window.cancelAnimationFrame(frameId);
+        removeListener();
+        resolve();
+      };
+
+      const removeListener = tileset.loadProgress.addEventListener(
+        (pending: number, processing: number) => {
+          if (pending === 0 && processing === 0) {
+            finish();
+          }
+        },
+      );
+
+      const timeoutId = window.setTimeout(finish, timeoutMs);
+
+      const scheduleNextPump = (): void => {
+        if (pumpIntervalMs > 0) {
+          pumpTimeoutId = window.setTimeout(pump, pumpIntervalMs);
+        } else {
+          frameId = window.requestAnimationFrame(pump);
+        }
+      };
+
+      const pump = (): void => {
+        if (hasSettled || tileset.isDestroyed() || tileset.tilesLoaded) {
+          finish();
+          return;
+        }
+        this.options.viewer.scene.requestRender();
+        scheduleNextPump();
+      };
+      pump();
+    });
+  }
+
+  private applyAppearance(tileset: Cesium3DTileset): void {
+    const shader = this.getShader();
+    if (tileset.customShader !== shader) {
+      tileset.customShader = shader;
+    }
+  }
+
+  /**
+   * One CustomShader instance is shared by every tileset of this axis, so a
+   * slice swap never triggers a GLSL compile/link. It is only rebuilt when the
+   * opaque/translucent mode flips, since that changes the generated source.
+   */
+  private getShader(): CustomShader {
+    const opacity = this.options.getOpacity();
+    const isOpaque = opacity === 1;
+    if (this.sharedShader === null || this.sharedShaderIsOpaque !== isOpaque) {
+      const previousShader = this.sharedShader;
+      this.sharedShader = this.options.makeShader();
+      this.sharedShaderIsOpaque = isOpaque;
+      // Re-point every live tileset before disposing the replaced shader,
+      // otherwise they would reference destroyed GPU resources.
+      for (const entry of this.cache.values()) {
+        if (!entry.tileset.isDestroyed()) {
+          entry.tileset.customShader = this.sharedShader;
+        }
+      }
+      destroyShader(previousShader);
+    }
+    this.sharedShader.setUniform('u_alpha', opacity);
+    return this.sharedShader;
+  }
+
+  private rememberCache(key: string, entry: CachedTileset): void {
+    this.cache.set(key, entry);
+    this.touchCache(key);
+    while (this.cacheOrder.length > MAX_CACHED_TILESETS) {
+      const evictKey = this.cacheOrder.find(
+        (candidate) => candidate !== key && candidate !== this.activeKey,
+      );
+      if (evictKey === undefined) {
+        break;
+      }
+      this.evictCacheKey(evictKey);
+    }
+  }
+
+  private touchCache(key: string): void {
+    const index = this.cacheOrder.indexOf(key);
+    if (index >= 0) {
+      this.cacheOrder.splice(index, 1);
+    }
+    this.cacheOrder.push(key);
+  }
+
+  private evictCacheKey(key: string): void {
+    const entry = this.cache.get(key);
+    if (entry === undefined) {
+      return;
+    }
+    this.cache.delete(key);
+    const orderIndex = this.cacheOrder.indexOf(key);
+    if (orderIndex >= 0) {
+      this.cacheOrder.splice(orderIndex, 1);
+    }
+    this.destroyCachedTileset(entry);
+    if (this.activeKey === key) {
+      this.tileset = null;
+      this.activeKey = null;
+    }
+  }
+
+  private async loadTileset(
+    resource: Resource,
+    show: boolean,
+  ): Promise<Cesium3DTileset> {
+    const tileset = await Cesium3DTileset.fromUrl(resource, {
+      ...TILESET_OPTIONS,
+      show,
+    });
+    // Belt-and-braces: ensure it's off even if `environmentMapOptions` isn't
+    // honored by this Cesium version's `fromUrl` (see `TILESET_OPTIONS`).
+    tileset.environmentMapManager.enabled = false;
+    tileset.imageBasedLighting = new ImageBasedLighting();
+    tileset.imageBasedLighting.imageBasedLightingFactor = new Cartesian2(1, 0);
+    return tileset;
+  }
+
+  /**
+   * Build a hidden tileset restricted to `numbers`. Not added to the scene yet
+   * so the caller can discard it if the selection changed meanwhile.
+   */
+  private async createTileset(
+    originalJson: unknown,
+    baseUrl: string,
+    headers: Record<string, string>,
+    direction: OgcSliceDirection,
+    numbers: readonly number[],
+  ): Promise<CachedTileset> {
+    const pruned = pruneTilesetToSlices(
+      originalJson,
+      { direction, numbers: new Set(numbers) },
+      baseUrl,
+    );
+    const blobUrl = toBlobUrl(pruned);
+    const resource = createAuthenticatedBlobResource(blobUrl, headers);
+    try {
+      const tileset = await this.loadTileset(resource, false);
+      return { tileset, blobUrl };
+    } catch (error) {
+      URL.revokeObjectURL(blobUrl);
+      throw error;
+    }
+  }
+
+  private destroyCachedTileset(entry: CachedTileset): void {
+    entry.releasePickLock?.();
+    entry.releasePickLock = undefined;
+    this.options.viewer.scene.primitives.remove(entry.tileset);
+    if (!entry.tileset.isDestroyed()) {
+      entry.tileset.destroy();
+    }
+    URL.revokeObjectURL(entry.blobUrl);
+  }
+
+  /**
+   * Builds the tileset for `key`, or joins an already in-flight build for it,
+   * ensuring it is added to the scene/cache exactly once. Both the
+   * interactive swap and background warming call this so a slider landing on
+   * a slice that is already being warmed does not race to build/add it
+   * twice — see the `inFlightBuilds` doc comment for why that duplication is
+   * unsafe.
+   */
+  private buildOrJoinTileset(
+    key: string,
+    originalJson: unknown,
+    baseUrl: string,
+    headers: Record<string, string>,
+    direction: OgcSliceDirection,
+    numbers: readonly number[],
+  ): Promise<CachedTileset> {
+    const cached = this.cache.get(key);
+    if (cached !== undefined && !cached.tileset.isDestroyed()) {
+      return Promise.resolve(cached);
+    }
+
+    const inFlight = this.inFlightBuilds.get(key);
+    if (inFlight !== undefined) {
+      return inFlight;
+    }
+
+    const build = this.createTileset(
+      originalJson,
+      baseUrl,
+      headers,
+      direction,
+      numbers,
+    )
+      .then((created) => {
+        // Another caller may have finished and cached this key while we were
+        // awaiting network/parse work — never add a second copy to the scene.
+        const winner = this.cache.get(key);
+        if (winner !== undefined && !winner.tileset.isDestroyed()) {
+          this.destroyCachedTileset(created);
+          return winner;
+        }
+        if (this.isDestroyed) {
+          this.destroyCachedTileset(created);
+          return created;
+        }
+        this.addToScene(key, created);
+        return created;
+      })
+      .finally(() => {
+        if (this.inFlightBuilds.get(key) === build) {
+          this.inFlightBuilds.delete(key);
+        }
+      });
+
+    this.inFlightBuilds.set(key, build);
+    return build;
+  }
+
+  private attachPickLock(tileset: Cesium3DTileset): () => void {
+    const pickService = PickService.get();
+    // Locks are tracked per tileset: several slice tilesets can be loading at
+    // once, and a shared field would leak a lock and disable picking for good.
+    let lock: ScenePickingLock | null = pickService.acquireScenePickingLock();
+    const removeListener = tileset.loadProgress.addEventListener(
+      (numberOfPendingRequests: number, numberOfTilesProcessing: number) => {
+        if (numberOfPendingRequests === 0 && numberOfTilesProcessing === 0) {
+          lock?.release();
+          lock = null;
+        } else {
+          lock ??= pickService.acquireScenePickingLock();
+        }
+      },
+    );
+    return () => {
+      removeListener();
+      lock?.release();
+      lock = null;
+    };
+  }
+
+  private destroyAll(): void {
+    this.isDestroyed = true;
+    this.loadGeneration += 1;
+    this.warmGeneration += 1;
+    this.scenePickingLock?.release();
+    this.scenePickingLock = null;
+    for (const key of [...this.cache.keys()]) {
+      this.evictCacheKey(key);
+    }
+    this.tileset = null;
+    this.activeKey = null;
+    destroyShader(this.sharedShader);
+    this.sharedShader = null;
+  }
+}
+
+/** Cesium does not dispose a tileset's `customShader`, so we own its lifetime. */
+const destroyShader = (shader: CustomShader | null): void => {
+  if (shader !== null && !shader.isDestroyed()) {
+    shader.destroy();
+  }
+};
+
+/**
+ * Hide a tileset and stop it from traversing / requesting tiles every frame.
+ * Already-loaded content stays resident, so re-showing it is instant.
+ */
+const freezeHidden = (tileset: Cesium3DTileset): void => {
+  tileset.show = false;
+  tileset.preloadWhenHidden = false;
+};
+
+export { TILESET_OPTIONS };

--- a/ui/src/features/layer/slice/axis-tileset-slot.ts
+++ b/ui/src/features/layer/slice/axis-tileset-slot.ts
@@ -171,7 +171,8 @@ export class AxisTilesetSlot {
     // (see `performSetSlices`/`clear`) — use `null` here too so comparisons
     // against `this.activeKey` below correctly recognise "this call's own
     // (empty) selection is the one that is currently active".
-    const key = numbers.length === 0 ? null : `${direction}:${numbers.join(',')}`;
+    const key =
+      numbers.length === 0 ? null : `${direction}:${numbers.join(',')}`;
 
     // Fast path: if the target slice is already loaded, swap synchronously.
     // This must bypass the update queue entirely — otherwise a warmed slice

--- a/ui/src/features/layer/slice/axis-tileset-slot.ts
+++ b/ui/src/features/layer/slice/axis-tileset-slot.ts
@@ -715,7 +715,7 @@ export class AxisTilesetSlot {
         }
         if (this.isDestroyed) {
           this.destroyCachedTileset(created);
-          return created;
+          throw new Error('AxisTilesetSlot destroyed during tileset build');
         }
         this.addToScene(key, created);
         return created;

--- a/ui/src/features/layer/slice/axis-tileset-slot.ts
+++ b/ui/src/features/layer/slice/axis-tileset-slot.ts
@@ -120,7 +120,17 @@ export class AxisTilesetSlot {
     direction: OgcSliceDirection;
     numbers: number[];
   } | null = null;
-  private readonly pendingResolvers: Array<() => void> = [];
+  /**
+   * Queued callers waiting for their own `setSlices()` call to be applied.
+   * Each entry remembers the key the caller asked for so it can be told,
+   * once the queue drains, whether *its* selection ended up active or was
+   * itself superseded by a later call before ever being applied — callers
+   * (e.g. neighbourhood prefetch/warming) must not act on a stale center.
+   */
+  private readonly pendingResolvers: Array<{
+    resolve: (isActive: boolean) => void;
+    key: string | null;
+  }> = [];
   /**
    * Tracks tileset builds in progress, keyed the same way as `cache`. Both
    * the interactive swap path and background warming can want the same slice
@@ -137,30 +147,46 @@ export class AxisTilesetSlot {
     return this.tileset;
   }
 
+  /**
+   * Selects the slice(s) shown on this axis.
+   *
+   * Resolves to `true` if this call's own selection is the one that ended up
+   * active on this axis, or `false` if it was itself superseded by a later
+   * call before ever being (or while being) applied. Callers that act on the
+   * *result* of a selection (e.g. prioritizing/warming the neighbourhood
+   * around the newly selected slice) must skip that follow-up work when this
+   * resolves `false`, since the center they have is no longer current.
+   */
   async setSlices(
     originalJson: unknown,
     baseUrl: string,
     headers: Record<string, string>,
     direction: OgcSliceDirection,
     numbers: number[],
-  ): Promise<void> {
+  ): Promise<boolean> {
     // A new selection wins over any background warming.
     this.warmGeneration += 1;
+
+    // `numbers.length === 0` clears the axis, i.e. leaves `activeKey` `null`
+    // (see `performSetSlices`/`clear`) — use `null` here too so comparisons
+    // against `this.activeKey` below correctly recognise "this call's own
+    // (empty) selection is the one that is currently active".
+    const key = numbers.length === 0 ? null : `${direction}:${numbers.join(',')}`;
 
     // Fast path: if the target slice is already loaded, swap synchronously.
     // This must bypass the update queue entirely — otherwise a warmed slice
     // would still be held back behind an in-flight load of a slice the user
     // has already scrubbed past.
     if (this.tryRevealLoaded(direction, numbers)) {
-      return;
+      return true;
     }
 
     if (this.isUpdating) {
       this.pending = { originalJson, baseUrl, headers, direction, numbers };
       // Resolve only once the queued selection has actually been applied, so
       // callers do not start warming a neighbourhood that is already stale.
-      return new Promise<void>((resolve) => {
-        this.pendingResolvers.push(resolve);
+      return new Promise<boolean>((resolve) => {
+        this.pendingResolvers.push({ resolve, key });
       });
     }
 
@@ -186,10 +212,13 @@ export class AxisTilesetSlot {
       }
     } finally {
       this.isUpdating = false;
-      for (const resolve of this.pendingResolvers.splice(0)) {
-        resolve();
+      for (const { resolve, key: pendingKey } of this.pendingResolvers.splice(
+        0,
+      )) {
+        resolve(pendingKey === this.activeKey);
       }
     }
+    return key === this.activeKey;
   }
 
   /**
@@ -245,7 +274,11 @@ export class AxisTilesetSlot {
   ): Promise<boolean> {
     const key = `${direction}:${number}`;
     const existing = this.cache.get(key);
-    if (existing !== undefined && !existing.tileset.isDestroyed()) {
+    if (
+      existing !== undefined &&
+      !existing.tileset.isDestroyed() &&
+      existing.tileset.tilesLoaded
+    ) {
       return true;
     }
     if (this.isUpdating) {
@@ -340,6 +373,10 @@ export class AxisTilesetSlot {
   /** Hide this axis without destroying (used in Multiple mode for inactive axes). */
   clear(): void {
     this.loadGeneration += 1;
+    // Also stop any in-flight background warming for this axis — otherwise a
+    // still-running `warmSlices()` loop keeps requesting/building tilesets
+    // for an axis that is no longer shown.
+    this.warmGeneration += 1;
     if (this.tileset !== null) {
       freezeHidden(this.tileset);
     }

--- a/ui/src/features/layer/slice/index.ts
+++ b/ui/src/features/layer/slice/index.ts
@@ -1,0 +1,6 @@
+export * from './tiles3d-slice.types';
+export * from './tileset-slice-metadata';
+export * from './tileset-slice-prune';
+export * from './tileset-slice-prefetch';
+export * from './axis-tileset-slot';
+export * from './ogc-tileset-resolve';

--- a/ui/src/features/layer/slice/ogc-tileset-resolve.test.ts
+++ b/ui/src/features/layer/slice/ogc-tileset-resolve.test.ts
@@ -1,6 +1,5 @@
 // @vitest-environment jsdom
-// (uses `sessionStorage`, which the default `node` test environment lacks.)
-import { describe, expect, it, vi, afterEach } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   resolveOgcTilesetResource,
   rewriteOgcContentUrisToResolvedBase,
@@ -31,6 +30,30 @@ describe('rewriteOgcContentUrisToResolvedBase', () => {
     );
   });
 
+  it('preserves nested content subdirectories instead of flattening to the file name', () => {
+    const tileset = {
+      root: {
+        children: [
+          {
+            content: {
+              uri: 'https://ogc-api.gst-viewer.swissgeol.ch/collections/14279/styles/5/nested/dir/foo-slice-X-0.glb',
+            },
+          },
+        ],
+      },
+    };
+    const s3Url =
+      'https://swissgeol-ogc-api-cache-geometries.s3.eu-central-1.amazonaws.com/14279/tiles3d/5/Amplitude.json';
+
+    const rewritten = rewriteOgcContentUrisToResolvedBase(tileset, s3Url) as {
+      root: { children: Array<{ content: { uri: string } }> };
+    };
+
+    expect(rewritten.root.children[0].content.uri).toBe(
+      'https://swissgeol-ogc-api-cache-geometries.s3.eu-central-1.amazonaws.com/14279/tiles3d/5/nested/dir/foo-slice-X-0.glb',
+    );
+  });
+
   it('leaves tilesets unchanged when not resolved to S3', () => {
     const tileset = {
       root: {
@@ -50,111 +73,11 @@ describe('rewriteOgcContentUrisToResolvedBase', () => {
 describe('resolveOgcTilesetResource', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
-    sessionStorage.clear();
   });
 
-  it('prefers the known S3 cache URL before calling OGC', async () => {
-    const s3Url =
-      'https://swissgeol-ogc-api-cache-geometries.s3.eu-central-1.amazonaws.com/14279/tiles3d/5/Amplitude__2D_Seismic_data_.json';
-    const tilesetJson = {
-      root: {
-        children: [
-          {
-            content: {
-              uri: 'https://ogc-api.gst-viewer.swissgeol.ch/collections/14279/styles/5/a-slice-Z-1.glb',
-            },
-            metadata: {
-              properties: { sliceDirection: 'w', sliceNumber: 1 },
-            },
-          },
-        ],
-      },
-    };
-
-    const fetchMock = vi.fn(async (url: string) => {
-      if (String(url).includes('ogc-api.gst-viewer')) {
-        throw new Error('OGC should not be called when S3 succeeds');
-      }
-      return {
-        status: 200,
-        ok: true,
-        statusText: 'OK',
-        url: s3Url,
-        json: async () => tilesetJson,
-      };
-    });
-    vi.stubGlobal('fetch', fetchMock);
-
-    const resolved = await resolveOgcTilesetResource(
-      'https://ogc-api.gst-viewer.swissgeol.ch/collections/14279/styles/5/download_format/tiles3d',
-      { Authorization: 'Basic test' },
-    );
-
-    expect(resolved.baseUrl).toBe(s3Url);
-    expect(resolved.headers).toEqual({});
-    const rewritten = resolved.json as {
-      root: { children: Array<{ content: { uri: string } }> };
-    };
-    expect(rewritten.root.children[0].content.uri).toContain(
-      'amazonaws.com/14279/tiles3d/5/a-slice-Z-1.glb',
-    );
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining('amazonaws.com/14279/tiles3d/5/'),
-      expect.objectContaining({
-        headers: {},
-        redirect: 'follow',
-        credentials: 'omit',
-      }),
-    );
-  });
-
-  it('falls back to OGC when the known S3 URL fails', async () => {
-    const s3Url =
-      'https://swissgeol-ogc-api-cache-geometries.s3.eu-central-1.amazonaws.com/14279/tiles3d/5/tileset.json';
-    const tilesetJson = { root: { children: [] } };
-    const fetchMock = vi.fn(async (url: string) => {
-      if (String(url).includes('amazonaws.com')) {
-        return {
-          status: 403,
-          ok: false,
-          statusText: 'Forbidden',
-          url: String(url),
-        };
-      }
-      return {
-        status: 200,
-        ok: true,
-        statusText: 'OK',
-        url: s3Url,
-        json: async () => tilesetJson,
-      };
-    });
-    vi.stubGlobal('fetch', fetchMock);
-
-    const resolved = await resolveOgcTilesetResource(
-      'https://ogc-api.gst-viewer.swissgeol.ch/collections/14279/styles/5/download_format/tiles3d',
-      { Authorization: 'Basic test' },
-    );
-
-    expect(resolved.baseUrl).toBe(s3Url);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(fetchMock).toHaveBeenNthCalledWith(
-      2,
-      expect.stringContaining('ogc-api'),
-      expect.objectContaining({
-        headers: { Authorization: 'Basic test' },
-      }),
-    );
-  });
-
-  it('uses remembered S3 URL for unknown collections', async () => {
+  it('fetches the tileset via the OGC gateway with auth headers', async () => {
     const ogcUrl =
-      'https://ogc-api.gst-viewer.swissgeol.ch/collections/999/styles/1/download_format/tiles3d';
-    const s3Url =
-      'https://swissgeol-ogc-api-cache-geometries.s3.eu-central-1.amazonaws.com/999/tiles3d/1/x.json';
-    sessionStorage.setItem(`swissgeol:ogc-tileset-resolved:${ogcUrl}`, s3Url);
-
+      'https://ogc-api.gst-viewer.swissgeol.ch/collections/14279/styles/5/download_format/tiles3d';
     const tilesetJson = { root: { children: [] } };
     const fetchMock = vi.fn(async (url: string) => ({
       status: 200,
@@ -169,12 +92,63 @@ describe('resolveOgcTilesetResource', () => {
       Authorization: 'Basic test',
     });
 
-    expect(resolved.baseUrl).toBe(s3Url);
+    expect(resolved.baseUrl).toBe(ogcUrl);
+    // Final host is still OGC, so auth headers are kept for subsequent loads.
+    expect(resolved.headers).toEqual({ Authorization: 'Basic test' });
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock.mock.calls[0][0]).toBe(s3Url);
+    expect(fetchMock).toHaveBeenCalledWith(
+      ogcUrl,
+      expect.objectContaining({
+        headers: { Authorization: 'Basic test' },
+        redirect: 'follow',
+        credentials: 'omit',
+      }),
+    );
   });
 
-  it('throws when the tileset request fails and no fallback exists', async () => {
+  it('rewrites content URIs and drops auth headers when fetch follows a redirect to S3', async () => {
+    const ogcUrl =
+      'https://ogc-api.gst-viewer.swissgeol.ch/collections/14279/styles/5/download_format/tiles3d';
+    const s3Url =
+      'https://swissgeol-ogc-api-cache-geometries.s3.eu-central-1.amazonaws.com/14279/tiles3d/5/Amplitude__2D_Seismic_data_.json';
+    const tilesetJson = {
+      root: {
+        children: [
+          {
+            content: {
+              uri: 'https://ogc-api.gst-viewer.swissgeol.ch/collections/14279/styles/5/a-slice-Z-1.glb',
+            },
+          },
+        ],
+      },
+    };
+    // `redirect: 'follow'` means the browser/fetch already resolved the 307
+    // to S3 by the time we see the response — `response.url` is the final
+    // (S3) URL, which is exactly what we key the content-URI rewrite on.
+    const fetchMock = vi.fn(async () => ({
+      status: 200,
+      ok: true,
+      statusText: 'OK',
+      url: s3Url,
+      json: async () => tilesetJson,
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const resolved = await resolveOgcTilesetResource(ogcUrl, {
+      Authorization: 'Basic test',
+    });
+
+    expect(resolved.baseUrl).toBe(s3Url);
+    expect(resolved.headers).toEqual({});
+    const rewritten = resolved.json as {
+      root: { children: Array<{ content: { uri: string } }> };
+    };
+    expect(rewritten.root.children[0].content.uri).toBe(
+      'https://swissgeol-ogc-api-cache-geometries.s3.eu-central-1.amazonaws.com/14279/tiles3d/5/a-slice-Z-1.glb',
+    );
+  });
+
+  it('throws when the OGC request fails', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn(async () => ({
@@ -190,5 +164,20 @@ describe('resolveOgcTilesetResource', () => {
         Authorization: 'Basic test',
       }),
     ).rejects.toThrow(/Failed to fetch OGC tileset/);
+  });
+
+  it('throws a descriptive error on a network failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('Failed to fetch');
+      }),
+    );
+
+    await expect(
+      resolveOgcTilesetResource('https://ogc-api.gst-viewer.swissgeol.ch/x', {
+        Authorization: 'Basic test',
+      }),
+    ).rejects.toThrow(/Failed to fetch OGC tileset \(network\)/);
   });
 });

--- a/ui/src/features/layer/slice/ogc-tileset-resolve.test.ts
+++ b/ui/src/features/layer/slice/ogc-tileset-resolve.test.ts
@@ -1,0 +1,194 @@
+// @vitest-environment jsdom
+// (uses `sessionStorage`, which the default `node` test environment lacks.)
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import {
+  resolveOgcTilesetResource,
+  rewriteOgcContentUrisToResolvedBase,
+} from './ogc-tileset-resolve';
+
+describe('rewriteOgcContentUrisToResolvedBase', () => {
+  it('rewrites absolute OGC content URIs to the S3 tileset directory', () => {
+    const tileset = {
+      root: {
+        children: [
+          {
+            content: {
+              uri: 'https://ogc-api.gst-viewer.swissgeol.ch/collections/14279/styles/5/foo-slice-X-0.glb',
+            },
+          },
+        ],
+      },
+    };
+    const s3Url =
+      'https://swissgeol-ogc-api-cache-geometries.s3.eu-central-1.amazonaws.com/14279/tiles3d/5/Amplitude.json';
+
+    const rewritten = rewriteOgcContentUrisToResolvedBase(tileset, s3Url) as {
+      root: { children: Array<{ content: { uri: string } }> };
+    };
+
+    expect(rewritten.root.children[0].content.uri).toBe(
+      'https://swissgeol-ogc-api-cache-geometries.s3.eu-central-1.amazonaws.com/14279/tiles3d/5/foo-slice-X-0.glb',
+    );
+  });
+
+  it('leaves tilesets unchanged when not resolved to S3', () => {
+    const tileset = {
+      root: {
+        content: {
+          uri: 'https://ogc-api.gst-viewer.swissgeol.ch/collections/1/a.glb',
+        },
+      },
+    };
+    const result = rewriteOgcContentUrisToResolvedBase(
+      tileset,
+      'https://ogc-api.gst-viewer.swissgeol.ch/collections/1/tileset.json',
+    );
+    expect(result).toBe(tileset);
+  });
+});
+
+describe('resolveOgcTilesetResource', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    sessionStorage.clear();
+  });
+
+  it('prefers the known S3 cache URL before calling OGC', async () => {
+    const s3Url =
+      'https://swissgeol-ogc-api-cache-geometries.s3.eu-central-1.amazonaws.com/14279/tiles3d/5/Amplitude__2D_Seismic_data_.json';
+    const tilesetJson = {
+      root: {
+        children: [
+          {
+            content: {
+              uri: 'https://ogc-api.gst-viewer.swissgeol.ch/collections/14279/styles/5/a-slice-Z-1.glb',
+            },
+            metadata: {
+              properties: { sliceDirection: 'w', sliceNumber: 1 },
+            },
+          },
+        ],
+      },
+    };
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (String(url).includes('ogc-api.gst-viewer')) {
+        throw new Error('OGC should not be called when S3 succeeds');
+      }
+      return {
+        status: 200,
+        ok: true,
+        statusText: 'OK',
+        url: s3Url,
+        json: async () => tilesetJson,
+      };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const resolved = await resolveOgcTilesetResource(
+      'https://ogc-api.gst-viewer.swissgeol.ch/collections/14279/styles/5/download_format/tiles3d',
+      { Authorization: 'Basic test' },
+    );
+
+    expect(resolved.baseUrl).toBe(s3Url);
+    expect(resolved.headers).toEqual({});
+    const rewritten = resolved.json as {
+      root: { children: Array<{ content: { uri: string } }> };
+    };
+    expect(rewritten.root.children[0].content.uri).toContain(
+      'amazonaws.com/14279/tiles3d/5/a-slice-Z-1.glb',
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('amazonaws.com/14279/tiles3d/5/'),
+      expect.objectContaining({
+        headers: {},
+        redirect: 'follow',
+        credentials: 'omit',
+      }),
+    );
+  });
+
+  it('falls back to OGC when the known S3 URL fails', async () => {
+    const s3Url =
+      'https://swissgeol-ogc-api-cache-geometries.s3.eu-central-1.amazonaws.com/14279/tiles3d/5/tileset.json';
+    const tilesetJson = { root: { children: [] } };
+    const fetchMock = vi.fn(async (url: string) => {
+      if (String(url).includes('amazonaws.com')) {
+        return {
+          status: 403,
+          ok: false,
+          statusText: 'Forbidden',
+          url: String(url),
+        };
+      }
+      return {
+        status: 200,
+        ok: true,
+        statusText: 'OK',
+        url: s3Url,
+        json: async () => tilesetJson,
+      };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const resolved = await resolveOgcTilesetResource(
+      'https://ogc-api.gst-viewer.swissgeol.ch/collections/14279/styles/5/download_format/tiles3d',
+      { Authorization: 'Basic test' },
+    );
+
+    expect(resolved.baseUrl).toBe(s3Url);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('ogc-api'),
+      expect.objectContaining({
+        headers: { Authorization: 'Basic test' },
+      }),
+    );
+  });
+
+  it('uses remembered S3 URL for unknown collections', async () => {
+    const ogcUrl =
+      'https://ogc-api.gst-viewer.swissgeol.ch/collections/999/styles/1/download_format/tiles3d';
+    const s3Url =
+      'https://swissgeol-ogc-api-cache-geometries.s3.eu-central-1.amazonaws.com/999/tiles3d/1/x.json';
+    sessionStorage.setItem(`swissgeol:ogc-tileset-resolved:${ogcUrl}`, s3Url);
+
+    const tilesetJson = { root: { children: [] } };
+    const fetchMock = vi.fn(async (url: string) => ({
+      status: 200,
+      ok: true,
+      statusText: 'OK',
+      url: String(url),
+      json: async () => tilesetJson,
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const resolved = await resolveOgcTilesetResource(ogcUrl, {
+      Authorization: 'Basic test',
+    });
+
+    expect(resolved.baseUrl).toBe(s3Url);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe(s3Url);
+  });
+
+  it('throws when the tileset request fails and no fallback exists', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        status: 403,
+        ok: false,
+        statusText: 'Forbidden',
+        url: 'https://ogc-api.gst-viewer.swissgeol.ch/x',
+      })),
+    );
+
+    await expect(
+      resolveOgcTilesetResource('https://ogc-api.gst-viewer.swissgeol.ch/x', {
+        Authorization: 'Basic test',
+      }),
+    ).rejects.toThrow(/Failed to fetch OGC tileset/);
+  });
+});

--- a/ui/src/features/layer/slice/ogc-tileset-resolve.ts
+++ b/ui/src/features/layer/slice/ogc-tileset-resolve.ts
@@ -177,7 +177,8 @@ export const rewriteOgcContentUrisToResolvedBase = (
     if (!resolved.host.includes('amazonaws.com')) {
       return tilesetJson;
     }
-    s3Directory = resolved.href.replace(/[^/]+$/, '');
+    const lastSlash = resolved.href.lastIndexOf('/');
+    s3Directory = lastSlash >= 0 ? resolved.href.slice(0, lastSlash + 1) : '';
   } catch {
     return tilesetJson;
   }

--- a/ui/src/features/layer/slice/ogc-tileset-resolve.ts
+++ b/ui/src/features/layer/slice/ogc-tileset-resolve.ts
@@ -1,0 +1,212 @@
+/**
+ * Resolve an OGC tileset download URL that 307-redirects to a public S3 cache.
+ *
+ * Browsers strip Authorization on cross-origin redirects. The follow-up request
+ * to S3 then fails CORS when credentials were used (`Access-Control-Allow-Origin: *`
+ * is incompatible with credentialed requests). We therefore load the tileset JSON
+ * with `fetch` (auth only on the initial OGC hop; the browser drops it on the S3
+ * redirect) and rewrite content URIs to the public S3 directory so Cesium never
+ * issues credentialed requests against S3.
+ *
+ * Note: `redirect: 'manual'` cannot be used here — cross-origin 307s become
+ * opaque redirects and the Location header is inaccessible.
+ *
+ * When the OGC gateway is down (e.g. 502), we fall back to a previously resolved
+ * S3 URL (sessionStorage) or a known public cache entry for local/dev layers.
+ */
+
+const OGC_HOST = 'ogc-api.gst-viewer.swissgeol.ch';
+const S3_CACHE_HOST =
+  'swissgeol-ogc-api-cache-geometries.s3.eu-central-1.amazonaws.com';
+const RESOLVED_URL_STORAGE_PREFIX = 'swissgeol:ogc-tileset-resolved:';
+/** Give up on the OGC gateway quickly and use the public S3 cache instead. */
+const OGC_FETCH_TIMEOUT_MS = 8_000;
+
+/**
+ * Known public S3 tileset URLs used when the OGC API is unavailable.
+ * Keyed by OGC path suffix (`/collections/{id}/styles/{style}/download_format/tiles3d`).
+ */
+const KNOWN_S3_TILESET_FALLBACKS: Readonly<Record<string, string>> = {
+  '/collections/14279/styles/5/download_format/tiles3d': `https://${S3_CACHE_HOST}/14279/tiles3d/5/Amplitude__2D_Seismic_data_.json`,
+};
+
+export interface ResolvedTileset {
+  json: unknown;
+  /** Final URL after redirects (typically the S3 cache object). */
+  baseUrl: string;
+  /** Headers for subsequent Cesium loads — empty when the final host is public. */
+  headers: Record<string, string>;
+}
+
+export const resolveOgcTilesetResource = async (
+  initialUrl: string,
+  authHeaders: Record<string, string>,
+): Promise<ResolvedTileset> => {
+  // Prefer a known/remembered public S3 URL first — the OGC gateway currently
+  // hangs or returns 502 for long periods, which blocked the whole layer load.
+  const fallbackUrl = findFallbackUrl(initialUrl);
+  if (fallbackUrl !== null) {
+    try {
+      return await fetchTilesetJson(fallbackUrl, {}, 60_000);
+    } catch (fallbackError) {
+      console.warn(
+        'Public S3 tileset fallback failed; trying OGC API:',
+        fallbackError,
+      );
+    }
+  }
+
+  try {
+    const resolved = await fetchTilesetJson(initialUrl, authHeaders);
+    rememberResolvedUrl(initialUrl, resolved.baseUrl);
+    return resolved;
+  } catch (primaryError) {
+    if (fallbackUrl === null) {
+      throw primaryError;
+    }
+    console.warn(
+      'OGC tileset resolve failed; retrying public S3 fallback:',
+      primaryError,
+    );
+    return fetchTilesetJson(fallbackUrl, {}, 60_000);
+  }
+};
+
+const fetchTilesetJson = async (
+  url: string,
+  headers: Record<string, string>,
+  timeoutMs: number = OGC_FETCH_TIMEOUT_MS,
+): Promise<ResolvedTileset> => {
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'GET',
+      headers,
+      redirect: 'follow',
+      credentials: 'omit',
+      mode: 'cors',
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (error) {
+    throw new Error(
+      `Failed to fetch OGC tileset (network): ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch OGC tileset: [${response.status} ${response.statusText}] ${url}`,
+    );
+  }
+
+  const baseUrl = response.url !== '' ? response.url : url;
+  const json: unknown = await response.json();
+  const rewritten = rewriteOgcContentUrisToResolvedBase(json, baseUrl);
+  return {
+    json: rewritten,
+    baseUrl,
+    headers: shouldSendOgcAuth(baseUrl) ? { ...headers } : {},
+  };
+};
+
+const findFallbackUrl = (initialUrl: string): string | null => {
+  const remembered = readRememberedUrl(initialUrl);
+  if (remembered !== null) {
+    return remembered;
+  }
+  try {
+    const path = new URL(initialUrl).pathname;
+    return KNOWN_S3_TILESET_FALLBACKS[path] ?? null;
+  } catch {
+    return null;
+  }
+};
+
+const rememberResolvedUrl = (initialUrl: string, resolvedUrl: string): void => {
+  if (typeof sessionStorage === 'undefined') {
+    return;
+  }
+  try {
+    if (!resolvedUrl.includes('amazonaws.com')) {
+      return;
+    }
+    sessionStorage.setItem(
+      RESOLVED_URL_STORAGE_PREFIX + initialUrl,
+      resolvedUrl,
+    );
+  } catch {
+    // Ignore quota / private-mode failures.
+  }
+};
+
+const readRememberedUrl = (initialUrl: string): string | null => {
+  if (typeof sessionStorage === 'undefined') {
+    return null;
+  }
+  try {
+    return sessionStorage.getItem(RESOLVED_URL_STORAGE_PREFIX + initialUrl);
+  } catch {
+    return null;
+  }
+};
+
+const shouldSendOgcAuth = (url: string): boolean => {
+  try {
+    return new URL(url).host === OGC_HOST;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Content URIs in the tileset often still point at the OGC API (which 307s to
+ * S3). Rewrite them to the same directory as the resolved tileset JSON so Cesium
+ * loads public S3 objects directly without credentialed CORS issues.
+ */
+export const rewriteOgcContentUrisToResolvedBase = (
+  tilesetJson: unknown,
+  resolvedTilesetUrl: string,
+): unknown => {
+  if (tilesetJson === null || typeof tilesetJson !== 'object') {
+    return tilesetJson;
+  }
+
+  let s3Directory: string;
+  try {
+    const resolved = new URL(resolvedTilesetUrl);
+    if (!resolved.host.includes('amazonaws.com')) {
+      return tilesetJson;
+    }
+    s3Directory = resolved.href.replace(/[^/]+$/, '');
+  } catch {
+    return tilesetJson;
+  }
+
+  const clone = structuredClone(tilesetJson) as {
+    root?: TilesetNode;
+  };
+
+  const rewrite = (node: TilesetNode | undefined): void => {
+    if (node === undefined) {
+      return;
+    }
+    const uri = node.content?.uri;
+    if (typeof uri === 'string' && uri.includes(OGC_HOST)) {
+      const fileName = uri.split('/').pop();
+      if (fileName !== undefined && fileName !== '') {
+        node.content!.uri = `${s3Directory}${fileName}`;
+      }
+    }
+    for (const child of node.children ?? []) {
+      rewrite(child);
+    }
+  };
+
+  rewrite(clone.root);
+  return clone;
+};
+
+interface TilesetNode {
+  content?: { uri?: string };
+  children?: TilesetNode[];
+}

--- a/ui/src/features/layer/slice/ogc-tileset-resolve.ts
+++ b/ui/src/features/layer/slice/ogc-tileset-resolve.ts
@@ -10,25 +10,13 @@
  *
  * Note: `redirect: 'manual'` cannot be used here — cross-origin 307s become
  * opaque redirects and the Location header is inaccessible.
- *
- * When the OGC gateway is down (e.g. 502), we fall back to a previously resolved
- * S3 URL (sessionStorage) or a known public cache entry for local/dev layers.
  */
 
 const OGC_HOST = 'ogc-api.gst-viewer.swissgeol.ch';
 const S3_CACHE_HOST =
   'swissgeol-ogc-api-cache-geometries.s3.eu-central-1.amazonaws.com';
-const RESOLVED_URL_STORAGE_PREFIX = 'swissgeol:ogc-tileset-resolved:';
-/** Give up on the OGC gateway quickly and use the public S3 cache instead. */
+/** Give up on a hung/unresponsive OGC gateway rather than blocking indefinitely. */
 const OGC_FETCH_TIMEOUT_MS = 8_000;
-
-/**
- * Known public S3 tileset URLs used when the OGC API is unavailable.
- * Keyed by OGC path suffix (`/collections/{id}/styles/{style}/download_format/tiles3d`).
- */
-const KNOWN_S3_TILESET_FALLBACKS: Readonly<Record<string, string>> = {
-  '/collections/14279/styles/5/download_format/tiles3d': `https://${S3_CACHE_HOST}/14279/tiles3d/5/Amplitude__2D_Seismic_data_.json`,
-};
 
 export interface ResolvedTileset {
   json: unknown;
@@ -39,43 +27,8 @@ export interface ResolvedTileset {
 }
 
 export const resolveOgcTilesetResource = async (
-  initialUrl: string,
-  authHeaders: Record<string, string>,
-): Promise<ResolvedTileset> => {
-  // Prefer a known/remembered public S3 URL first — the OGC gateway currently
-  // hangs or returns 502 for long periods, which blocked the whole layer load.
-  const fallbackUrl = findFallbackUrl(initialUrl);
-  if (fallbackUrl !== null) {
-    try {
-      return await fetchTilesetJson(fallbackUrl, {}, 60_000);
-    } catch (fallbackError) {
-      console.warn(
-        'Public S3 tileset fallback failed; trying OGC API:',
-        fallbackError,
-      );
-    }
-  }
-
-  try {
-    const resolved = await fetchTilesetJson(initialUrl, authHeaders);
-    rememberResolvedUrl(initialUrl, resolved.baseUrl);
-    return resolved;
-  } catch (primaryError) {
-    if (fallbackUrl === null) {
-      throw primaryError;
-    }
-    console.warn(
-      'OGC tileset resolve failed; retrying public S3 fallback:',
-      primaryError,
-    );
-    return fetchTilesetJson(fallbackUrl, {}, 60_000);
-  }
-};
-
-const fetchTilesetJson = async (
   url: string,
   headers: Record<string, string>,
-  timeoutMs: number = OGC_FETCH_TIMEOUT_MS,
 ): Promise<ResolvedTileset> => {
   let response: Response;
   try {
@@ -85,7 +38,7 @@ const fetchTilesetJson = async (
       redirect: 'follow',
       credentials: 'omit',
       mode: 'cors',
-      signal: AbortSignal.timeout(timeoutMs),
+      signal: AbortSignal.timeout(OGC_FETCH_TIMEOUT_MS),
     });
   } catch (error) {
     throw new Error(
@@ -109,50 +62,18 @@ const fetchTilesetJson = async (
   };
 };
 
-const findFallbackUrl = (initialUrl: string): string | null => {
-  const remembered = readRememberedUrl(initialUrl);
-  if (remembered !== null) {
-    return remembered;
-  }
-  try {
-    const path = new URL(initialUrl).pathname;
-    return KNOWN_S3_TILESET_FALLBACKS[path] ?? null;
-  } catch {
-    return null;
-  }
-};
-
-const rememberResolvedUrl = (initialUrl: string, resolvedUrl: string): void => {
-  if (typeof sessionStorage === 'undefined') {
-    return;
-  }
-  try {
-    if (!resolvedUrl.includes('amazonaws.com')) {
-      return;
-    }
-    sessionStorage.setItem(
-      RESOLVED_URL_STORAGE_PREFIX + initialUrl,
-      resolvedUrl,
-    );
-  } catch {
-    // Ignore quota / private-mode failures.
-  }
-};
-
-const readRememberedUrl = (initialUrl: string): string | null => {
-  if (typeof sessionStorage === 'undefined') {
-    return null;
-  }
-  try {
-    return sessionStorage.getItem(RESOLVED_URL_STORAGE_PREFIX + initialUrl);
-  } catch {
-    return null;
-  }
-};
-
 const shouldSendOgcAuth = (url: string): boolean => {
   try {
     return new URL(url).host === OGC_HOST;
+  } catch {
+    return false;
+  }
+};
+
+/** Exact-host check — `includes()` would also match unrelated hosts that merely contain the substring. */
+const isS3CacheUrl = (url: string): boolean => {
+  try {
+    return new URL(url).host === S3_CACHE_HOST;
   } catch {
     return false;
   }
@@ -173,10 +94,10 @@ export const rewriteOgcContentUrisToResolvedBase = (
 
   let s3Directory: string;
   try {
-    const resolved = new URL(resolvedTilesetUrl);
-    if (!resolved.host.includes('amazonaws.com')) {
+    if (!isS3CacheUrl(resolvedTilesetUrl)) {
       return tilesetJson;
     }
+    const resolved = new URL(resolvedTilesetUrl);
     const lastSlash = resolved.href.lastIndexOf('/');
     s3Directory = lastSlash >= 0 ? resolved.href.slice(0, lastSlash + 1) : '';
   } catch {
@@ -193,9 +114,9 @@ export const rewriteOgcContentUrisToResolvedBase = (
     }
     const uri = node.content?.uri;
     if (typeof uri === 'string' && uri.includes(OGC_HOST)) {
-      const fileName = uri.split('/').pop();
-      if (fileName !== undefined && fileName !== '') {
-        node.content!.uri = `${s3Directory}${fileName}`;
+      const relativePath = ogcContentRelativePath(uri);
+      if (relativePath !== null) {
+        node.content!.uri = `${s3Directory}${relativePath}`;
       }
     }
     for (const child of node.children ?? []) {
@@ -205,6 +126,30 @@ export const rewriteOgcContentUrisToResolvedBase = (
 
   rewrite(clone.root);
   return clone;
+};
+
+/**
+ * `/collections/{id}/styles/{style}/...` is the OGC routing prefix; whatever
+ * follows it is the content's actual storage path, which may be nested in
+ * subdirectories rather than sitting flat next to the tileset JSON. Falls
+ * back to just the file name when the URI does not match this shape (e.g. an
+ * unexpected/older layout), matching the previous flat behaviour.
+ */
+const OGC_CONTENT_PATH_PREFIX = /^\/collections\/[^/]+\/styles\/[^/]+\/(.+)$/;
+
+const ogcContentRelativePath = (uri: string): string | null => {
+  let path: string;
+  try {
+    path = new URL(uri).pathname;
+  } catch {
+    path = uri;
+  }
+  const match = OGC_CONTENT_PATH_PREFIX.exec(path);
+  if (match !== null) {
+    return match[1];
+  }
+  const fileName = path.split('/').pop();
+  return fileName !== undefined && fileName !== '' ? fileName : null;
 };
 
 interface TilesetNode {

--- a/ui/src/features/layer/slice/tiles3d-slice.types.ts
+++ b/ui/src/features/layer/slice/tiles3d-slice.types.ts
@@ -137,9 +137,12 @@ export const SLICE_PREFETCH_RADIUS = 8;
  * current slider position, so stepping to a neighbour needs no loading at all.
  *
  * Each warmed slice holds a decoded texture in GPU memory, and there are three
- * axes, so this is a direct VRAM/scrub-smoothness trade-off.
+ * axes warming concurrently, so a radius of N means up to `(2N + 1) * 3`
+ * tilesets are built/held at once — keep this modest; scrubbing rarely jumps
+ * far in one step, and a too-large radius competes for network/GPU with the
+ * interactive swap itself (the very thing this is meant to keep fast).
  */
-export const SLICE_GPU_WARM_RADIUS = 6;
+export const SLICE_GPU_WARM_RADIUS = 3;
 
 export const isDefaultSliceSelection = (
   selection: Tiles3dSliceSelection,

--- a/ui/src/features/layer/slice/tiles3d-slice.types.ts
+++ b/ui/src/features/layer/slice/tiles3d-slice.types.ts
@@ -1,0 +1,160 @@
+/** OGC tileset slice direction (collection metadata). */
+export type OgcSliceDirection = 'u' | 'v' | 'w';
+
+/** UI / layer-model axis names (Figma: Crossline / Inline / Depth). */
+export type SeismicSliceAxis = 'crossline' | 'inline' | 'depth';
+
+export type SliceViewMode = 'single' | 'multiple';
+
+export const SEISMIC_SLICE_AXES: readonly SeismicSliceAxis[] = [
+  'crossline',
+  'inline',
+  'depth',
+] as const;
+
+export const AXIS_TO_DIRECTION: Record<SeismicSliceAxis, OgcSliceDirection> = {
+  crossline: 'u',
+  inline: 'v',
+  depth: 'w',
+};
+
+export const DIRECTION_TO_AXIS: Record<OgcSliceDirection, SeismicSliceAxis> = {
+  u: 'crossline',
+  v: 'inline',
+  w: 'depth',
+};
+
+/** Soft limit shown as a warning in Multiple mode (Figma). */
+export const RECOMMENDED_MAX_SLICES_BY_AXIS: Record<SeismicSliceAxis, number> =
+  {
+    crossline: 4,
+    inline: 4,
+    depth: 4,
+  };
+
+export interface TilesetSliceAxisInfo {
+  direction: OgcSliceDirection;
+  axis: SeismicSliceAxis;
+  /** Sorted unique slice numbers available on this axis. */
+  numbers: number[];
+}
+
+export interface TilesetSliceMetadata {
+  axes: Partial<Record<SeismicSliceAxis, TilesetSliceAxisInfo>>;
+  counts: Partial<Record<SeismicSliceAxis, number>>;
+}
+
+export interface Tiles3dSliceSelection {
+  mode: SliceViewMode;
+  /** Selected slice number per axis (Single mode). */
+  single: Record<SeismicSliceAxis, number>;
+  multiple: {
+    axis: SeismicSliceAxis;
+    count: number;
+  };
+}
+
+export const hasSliceMetadata = (
+  metadata: TilesetSliceMetadata | null,
+): metadata is TilesetSliceMetadata => {
+  if (metadata === null) {
+    return false;
+  }
+  return SEISMIC_SLICE_AXES.some(
+    (axis) => (metadata.axes[axis]?.numbers.length ?? 0) > 0,
+  );
+};
+
+export const createDefaultSliceSelection = (
+  metadata: TilesetSliceMetadata,
+): Tiles3dSliceSelection => {
+  const middle = (numbers: number[]): number =>
+    numbers.length === 0 ? 0 : numbers[Math.floor(numbers.length / 2)];
+
+  return {
+    mode: 'single',
+    single: {
+      crossline: middle(metadata.axes.crossline?.numbers ?? []),
+      inline: middle(metadata.axes.inline?.numbers ?? []),
+      depth: middle(metadata.axes.depth?.numbers ?? []),
+    },
+    multiple: {
+      axis: 'crossline',
+      count: 1,
+    },
+  };
+};
+
+/**
+ * Pick `count` evenly spaced numbers from a sorted list (linspace).
+ * A single slice uses the middle value.
+ */
+export const evenlySpacedSliceNumbers = (
+  numbers: number[],
+  count: number,
+): number[] => {
+  if (numbers.length === 0 || count <= 0) {
+    return [];
+  }
+  const n = Math.min(count, numbers.length);
+  if (n === 1) {
+    return [numbers[Math.floor(numbers.length / 2)]];
+  }
+  const result: number[] = [];
+  for (let i = 0; i < n; i++) {
+    const idx = Math.round((i * (numbers.length - 1)) / (n - 1));
+    result.push(numbers[idx]);
+  }
+  return [...new Set(result)];
+};
+
+/**
+ * Neighboring slice numbers around `center` by index in the sorted `available`
+ * list (not by numeric ±radius, so gaps in numbering are handled).
+ */
+export const neighborhoodSliceNumbers = (
+  available: readonly number[],
+  center: number,
+  radius: number,
+): number[] => {
+  if (available.length === 0 || radius < 0) {
+    return [];
+  }
+  const index = available.indexOf(center);
+  if (index < 0) {
+    return [];
+  }
+  const start = Math.max(0, index - radius);
+  const end = Math.min(available.length - 1, index + radius);
+  return available.slice(start, end + 1);
+};
+
+/** Default half-window for GLB prefetch around the current slider position. */
+export const SLICE_PREFETCH_RADIUS = 8;
+
+/**
+ * Half-window of slices kept as fully loaded (hidden) tilesets around the
+ * current slider position, so stepping to a neighbour needs no loading at all.
+ *
+ * Each warmed slice holds a decoded texture in GPU memory, and there are three
+ * axes, so this is a direct VRAM/scrub-smoothness trade-off.
+ */
+export const SLICE_GPU_WARM_RADIUS = 6;
+
+export const isDefaultSliceSelection = (
+  selection: Tiles3dSliceSelection,
+  defaults: Tiles3dSliceSelection,
+): boolean => {
+  if (selection.mode !== defaults.mode) {
+    return false;
+  }
+  if (selection.mode === 'single') {
+    return SEISMIC_SLICE_AXES.every(
+      (axis) => selection.single[axis] === defaults.single[axis],
+    );
+  }
+  return (
+    selection.multiple.axis === defaults.multiple.axis &&
+    selection.multiple.count === defaults.multiple.count
+  );
+};

--- a/ui/src/features/layer/slice/tileset-slice-metadata.test.ts
+++ b/ui/src/features/layer/slice/tileset-slice-metadata.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   createDefaultSliceSelection,
   evenlySpacedSliceNumbers,
@@ -8,7 +8,6 @@ import {
 } from 'src/features/layer/slice/tiles3d-slice.types';
 import { parseTilesetSliceMetadata } from 'src/features/layer/slice/tileset-slice-metadata';
 import { pruneTilesetToSlices } from 'src/features/layer/slice/tileset-slice-prune';
-import { collectSliceContentUris } from 'src/features/layer/slice/tileset-slice-prefetch';
 import type { TilesetSliceMetadata } from 'src/features/layer/slice/tiles3d-slice.types';
 
 describe('evenlySpacedSliceNumbers', () => {
@@ -120,6 +119,43 @@ describe('parseTilesetSliceMetadata', () => {
       }),
     ).toBeNull();
   });
+
+  it('omits URI-only tiles rather than guessing their axis when the tileset is only partially annotated', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const tileset = {
+      root: {
+        metadata: {
+          properties: {
+            u_slices: 2,
+            v_slices: 2,
+            w_slices: 1,
+          },
+        },
+        children: [
+          // Directional metadata present for these two tiles...
+          sliceTile('u', 0, 'a-slice-0.glb'),
+          sliceTile('u', 1, 'a-slice-1.glb'),
+          // ...but these three only carry a URI-encoded slice number, so the
+          // count-based partition (which assumes *all* slices are unclaimed)
+          // cannot be safely applied to them.
+          uriTile('x-slice-2.glb'),
+          uriTile('x-slice-3.glb'),
+          uriTile('x-slice-4.glb'),
+        ],
+      },
+    };
+
+    const metadata = parseTilesetSliceMetadata(tileset);
+    expect(metadata!.axes.crossline?.numbers).toEqual([0, 1]);
+    expect(metadata!.axes.inline).toBeUndefined();
+    expect(metadata!.axes.depth).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '3 slice tile(s) have no sliceDirection/sliceNumber metadata',
+      ),
+    );
+    warn.mockRestore();
+  });
 });
 
 describe('createDefaultSliceSelection', () => {
@@ -226,25 +262,6 @@ describe('pruneTilesetToSlices', () => {
         'https://ogc.example/tileset.json',
       ),
     ).toThrow(/None of the selected slices/);
-  });
-});
-
-describe('collectSliceContentUris', () => {
-  it('returns absolute uris for matching direction and numbers', () => {
-    const tileset = {
-      root: {
-        children: [
-          sliceTile('u', 0, 'https://cdn.example/a-slice-0.glb'),
-          sliceTile('u', 1, 'https://cdn.example/a-slice-1.glb'),
-          sliceTile('v', 0, 'https://cdn.example/a-slice-2.glb'),
-        ],
-      },
-    };
-
-    expect(collectSliceContentUris(tileset, 'u', new Set([0, 1]))).toEqual([
-      'https://cdn.example/a-slice-0.glb',
-      'https://cdn.example/a-slice-1.glb',
-    ]);
   });
 });
 

--- a/ui/src/features/layer/slice/tileset-slice-metadata.test.ts
+++ b/ui/src/features/layer/slice/tileset-slice-metadata.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createDefaultSliceSelection,
+  evenlySpacedSliceNumbers,
+  hasSliceMetadata,
+  isDefaultSliceSelection,
+  neighborhoodSliceNumbers,
+} from 'src/features/layer/slice/tiles3d-slice.types';
+import { parseTilesetSliceMetadata } from 'src/features/layer/slice/tileset-slice-metadata';
+import { pruneTilesetToSlices } from 'src/features/layer/slice/tileset-slice-prune';
+import { collectSliceContentUris } from 'src/features/layer/slice/tileset-slice-prefetch';
+import type { TilesetSliceMetadata } from 'src/features/layer/slice/tiles3d-slice.types';
+
+describe('evenlySpacedSliceNumbers', () => {
+  it('returns empty for empty input', () => {
+    expect(evenlySpacedSliceNumbers([], 3)).toEqual([]);
+  });
+
+  it('returns the middle value for count 1', () => {
+    expect(evenlySpacedSliceNumbers([0, 1, 2, 3, 4], 1)).toEqual([2]);
+  });
+
+  it('includes first and last when count >= 2', () => {
+    expect(evenlySpacedSliceNumbers([0, 1, 2, 3, 4], 3)).toEqual([0, 2, 4]);
+  });
+
+  it('clamps count to available length', () => {
+    expect(evenlySpacedSliceNumbers([10, 20], 5)).toEqual([10, 20]);
+  });
+});
+
+describe('neighborhoodSliceNumbers', () => {
+  it('returns a window around the center index', () => {
+    expect(neighborhoodSliceNumbers([0, 1, 2, 3, 4, 5, 6], 3, 2)).toEqual([
+      1, 2, 3, 4, 5,
+    ]);
+  });
+
+  it('clamps to list bounds', () => {
+    expect(neighborhoodSliceNumbers([10, 20, 30], 10, 5)).toEqual([10, 20, 30]);
+  });
+
+  it('returns empty when center is missing', () => {
+    expect(neighborhoodSliceNumbers([0, 1, 2], 9, 2)).toEqual([]);
+  });
+});
+
+describe('orderNumbersFromCenter', () => {
+  it('orders by distance from center', async () => {
+    const { orderNumbersFromCenter } = await import('./tileset-slice-prefetch');
+    expect(orderNumbersFromCenter([0, 1, 2, 3, 4], 2)).toEqual([2, 1, 3, 0, 4]);
+  });
+});
+
+describe('parseTilesetSliceMetadata', () => {
+  it('parses directional metadata and counts', () => {
+    const tileset = {
+      root: {
+        metadata: {
+          properties: {
+            u_slices: 3,
+            v_slices: 2,
+            w_slices: 2,
+          },
+        },
+        children: [
+          sliceTile('u', 0, 'a-slice-0.glb'),
+          sliceTile('u', 1, 'a-slice-1.glb'),
+          sliceTile('u', 2, 'a-slice-2.glb'),
+          sliceTile('v', 0, 'a-slice-3.glb'),
+          sliceTile('v', 1, 'a-slice-4.glb'),
+          sliceTile('w', 0, 'a-slice-5.glb'),
+          sliceTile('w', 1, 'a-slice-6.glb'),
+        ],
+      },
+    };
+
+    const metadata = parseTilesetSliceMetadata(tileset);
+    expect(hasSliceMetadata(metadata)).toBe(true);
+    expect(metadata!.axes.crossline?.numbers).toEqual([0, 1, 2]);
+    expect(metadata!.axes.inline?.numbers).toEqual([0, 1]);
+    expect(metadata!.axes.depth?.numbers).toEqual([0, 1]);
+    expect(metadata!.counts).toEqual({
+      crossline: 3,
+      inline: 2,
+      depth: 2,
+    });
+  });
+
+  it('partitions URI-only slices by counts', () => {
+    const tileset = {
+      root: {
+        metadata: {
+          properties: {
+            u_slices: 2,
+            v_slices: 2,
+            w_slices: 1,
+          },
+        },
+        children: [
+          uriTile('x-slice-0.glb'),
+          uriTile('x-slice-1.glb'),
+          uriTile('x-slice-2.glb'),
+          uriTile('x-slice-3.glb'),
+          uriTile('x-slice-4.glb'),
+        ],
+      },
+    };
+
+    const metadata = parseTilesetSliceMetadata(tileset);
+    expect(metadata!.axes.crossline?.numbers).toEqual([0, 1]);
+    expect(metadata!.axes.inline?.numbers).toEqual([2, 3]);
+    expect(metadata!.axes.depth?.numbers).toEqual([4]);
+  });
+
+  it('returns null when no slice information is present', () => {
+    expect(
+      parseTilesetSliceMetadata({
+        root: { children: [{ content: { uri: 'model.glb' } }] },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('createDefaultSliceSelection', () => {
+  it('uses middle slice per axis in single mode', () => {
+    const metadata = {
+      axes: {
+        crossline: {
+          direction: 'u',
+          axis: 'crossline',
+          numbers: [0, 1, 2, 3, 4],
+        },
+        inline: { direction: 'v', axis: 'inline', numbers: [0, 1, 2] },
+        depth: { direction: 'w', axis: 'depth', numbers: [10, 20] },
+      },
+      counts: {},
+    } satisfies TilesetSliceMetadata;
+
+    const defaults = createDefaultSliceSelection(metadata);
+    expect(defaults.mode).toBe('single');
+    expect(defaults.single).toEqual({
+      crossline: 2,
+      inline: 1,
+      depth: 20,
+    });
+    expect(isDefaultSliceSelection(defaults, defaults)).toBe(true);
+    expect(
+      isDefaultSliceSelection(
+        { ...defaults, single: { ...defaults.single, crossline: 0 } },
+        defaults,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('pruneTilesetToSlices', () => {
+  it('keeps selected directional slices and rewrites absolute URIs', () => {
+    const tileset = {
+      root: {
+        geometricError: 100,
+        children: [
+          sliceTile('u', 0, 'data/a-slice-0.glb'),
+          sliceTile('u', 1, 'data/a-slice-1.glb'),
+          sliceTile('v', 0, 'data/a-slice-2.glb'),
+        ],
+      },
+    };
+
+    const pruned = pruneTilesetToSlices(
+      tileset,
+      { direction: 'u', numbers: new Set([1]) },
+      'https://ogc.example/collections/1/tileset.json',
+    );
+
+    expect(pruned.root?.children).toHaveLength(1);
+    expect(pruned.root?.children?.[0].content?.uri).toBe(
+      'https://ogc.example/collections/1/data/a-slice-1.glb',
+    );
+    expect(pruned.root?.geometricError).toBe(100);
+  });
+
+  it('tightens parent region bounds to kept children', () => {
+    const tileset = {
+      root: {
+        geometricError: 1000,
+        boundingVolume: {
+          region: [0, 0, 1, 1, -5000, 0],
+        },
+        children: [
+          {
+            ...sliceTile('u', 0, 'a-slice-0.glb'),
+            boundingVolume: { region: [0.1, 0.1, 0.2, 0.9, -100, 0] },
+            geometricError: 0,
+          },
+          {
+            ...sliceTile('u', 1, 'a-slice-1.glb'),
+            boundingVolume: { region: [0.4, 0.1, 0.5, 0.9, -100, 0] },
+            geometricError: 0,
+          },
+        ],
+      },
+    };
+
+    const pruned = pruneTilesetToSlices(
+      tileset,
+      { direction: 'u', numbers: new Set([0]) },
+      'https://ogc.example/tileset.json',
+    );
+
+    expect((pruned.root as any).boundingVolume.region).toEqual([
+      0.1, 0.1, 0.2, 0.9, -100, 0,
+    ]);
+    expect((pruned.root as any).geometricError).toBe(1000);
+  });
+
+  it('throws when no selected slices exist', () => {
+    expect(() =>
+      pruneTilesetToSlices(
+        {
+          root: {
+            children: [sliceTile('u', 0, 'a-slice-0.glb')],
+          },
+        },
+        { direction: 'u', numbers: new Set([99]) },
+        'https://ogc.example/tileset.json',
+      ),
+    ).toThrow(/None of the selected slices/);
+  });
+});
+
+describe('collectSliceContentUris', () => {
+  it('returns absolute uris for matching direction and numbers', () => {
+    const tileset = {
+      root: {
+        children: [
+          sliceTile('u', 0, 'https://cdn.example/a-slice-0.glb'),
+          sliceTile('u', 1, 'https://cdn.example/a-slice-1.glb'),
+          sliceTile('v', 0, 'https://cdn.example/a-slice-2.glb'),
+        ],
+      },
+    };
+
+    expect(collectSliceContentUris(tileset, 'u', new Set([0, 1]))).toEqual([
+      'https://cdn.example/a-slice-0.glb',
+      'https://cdn.example/a-slice-1.glb',
+    ]);
+  });
+});
+
+function sliceTile(
+  direction: 'u' | 'v' | 'w',
+  number: number,
+  uri: string,
+): object {
+  return {
+    content: { uri },
+    metadata: {
+      class: 'slice-metadata',
+      properties: {
+        sliceDirection: direction,
+        sliceNumber: number,
+      },
+    },
+  };
+}
+
+function uriTile(uri: string): object {
+  return { content: { uri } };
+}

--- a/ui/src/features/layer/slice/tileset-slice-metadata.ts
+++ b/ui/src/features/layer/slice/tileset-slice-metadata.ts
@@ -1,6 +1,5 @@
 import {
   AXIS_TO_DIRECTION,
-  DIRECTION_TO_AXIS,
   OgcSliceDirection,
   SEISMIC_SLICE_AXES,
   SeismicSliceAxis,
@@ -198,4 +197,4 @@ export const readTileSliceKey = (
   return null;
 };
 
-export { DIRECTION_TO_AXIS };
+export { DIRECTION_TO_AXIS } from 'src/features/layer/slice/tiles3d-slice.types';

--- a/ui/src/features/layer/slice/tileset-slice-metadata.ts
+++ b/ui/src/features/layer/slice/tileset-slice-metadata.ts
@@ -205,14 +205,26 @@ const partitionUriSlicesByCounts = (
   assign('depth', wCount);
 };
 
-export const readTileSliceKey = (
+/**
+ * Resolve a tile's slice identity, preferring `sliceDirection`/`sliceNumber`
+ * metadata and falling back to parsing the slice number out of its content
+ * URI (direction `null` in that case, since a URI alone cannot tell axes
+ * apart). Shared by the prefetch and prune modules, which both need to know
+ * which slice a given tile belongs to.
+ */
+export const resolveSliceIdentity = (
   tile: TilesetTileNode,
-): { direction: OgcSliceDirection; number: number } | null => {
+  uri: string,
+): { direction: OgcSliceDirection | null; number: number } | null => {
   const fromMeta = readSliceIdentity(tile);
   if (fromMeta !== null) {
     return fromMeta;
   }
-  return null;
+  const fromUri = parseSliceFromUri(uri);
+  if (fromUri === null) {
+    return null;
+  }
+  return { direction: null, number: fromUri };
 };
 
 export { DIRECTION_TO_AXIS } from 'src/features/layer/slice/tiles3d-slice.types';

--- a/ui/src/features/layer/slice/tileset-slice-metadata.ts
+++ b/ui/src/features/layer/slice/tileset-slice-metadata.ts
@@ -1,0 +1,201 @@
+import {
+  AXIS_TO_DIRECTION,
+  DIRECTION_TO_AXIS,
+  OgcSliceDirection,
+  SEISMIC_SLICE_AXES,
+  SeismicSliceAxis,
+  TilesetSliceAxisInfo,
+  TilesetSliceMetadata,
+} from 'src/features/layer/slice/tiles3d-slice.types';
+
+interface TilesetTileNode {
+  content?: { uri?: string };
+  children?: TilesetTileNode[];
+  extras?: Record<string, unknown>;
+  metadata?: {
+    class?: string;
+    properties?: Record<string, unknown>;
+  };
+}
+
+interface TilesetJson {
+  root?: TilesetTileNode;
+  [key: string]: unknown;
+}
+
+const SLICE_URI_PATTERN = /-slice-(?:[XYZ]-)?(\d+)\.glb$/i;
+
+const isOgcSliceDirection = (value: unknown): value is OgcSliceDirection =>
+  value === 'u' || value === 'v' || value === 'w';
+
+/**
+ * Parse OGC 3D Tiles slice metadata from a tileset JSON.
+ *
+ * Prefers per-tile `sliceDirection` / `sliceNumber` and parent `u_slices` /
+ * `v_slices` / `w_slices` counts. Falls back to partitioning URI-based
+ * `-slice-N.glb` numbers by those counts when direction metadata is absent.
+ */
+export const parseTilesetSliceMetadata = (
+  tilesetJson: unknown,
+): TilesetSliceMetadata | null => {
+  if (tilesetJson === null || typeof tilesetJson !== 'object') {
+    return null;
+  }
+
+  const json = tilesetJson as TilesetJson;
+  if (json.root === undefined) {
+    return null;
+  }
+
+  const counts = collectSliceCounts(json.root);
+  const byDirection: Record<OgcSliceDirection, Set<number>> = {
+    u: new Set(),
+    v: new Set(),
+    w: new Set(),
+  };
+  const uriOnlyNumbers: number[] = [];
+
+  const visit = (tile: TilesetTileNode): void => {
+    const fromMeta = readSliceIdentity(tile);
+    if (fromMeta !== null) {
+      byDirection[fromMeta.direction].add(fromMeta.number);
+    } else {
+      const uri = tile.content?.uri;
+      if (uri !== undefined) {
+        const slice = parseSliceFromUri(uri);
+        if (slice !== null) {
+          uriOnlyNumbers.push(slice);
+        }
+      }
+    }
+
+    for (const child of tile.children ?? []) {
+      visit(child);
+    }
+  };
+  visit(json.root);
+
+  const hasDirectionalMeta = (['u', 'v', 'w'] as OgcSliceDirection[]).some(
+    (d) => byDirection[d].size > 0,
+  );
+
+  if (!hasDirectionalMeta && uriOnlyNumbers.length > 0) {
+    partitionUriSlicesByCounts(uriOnlyNumbers, counts, byDirection);
+  }
+
+  const axes: Partial<Record<SeismicSliceAxis, TilesetSliceAxisInfo>> = {};
+  for (const axis of SEISMIC_SLICE_AXES) {
+    const direction = AXIS_TO_DIRECTION[axis];
+    const numbers = [...byDirection[direction]].sort((a, b) => a - b);
+    if (numbers.length === 0) {
+      continue;
+    }
+    axes[axis] = { direction, axis, numbers };
+  }
+
+  if (Object.keys(axes).length === 0) {
+    return null;
+  }
+
+  return { axes, counts };
+};
+
+const collectSliceCounts = (
+  root: TilesetTileNode,
+): Partial<Record<SeismicSliceAxis, number>> => {
+  const counts: Partial<Record<SeismicSliceAxis, number>> = {};
+
+  const visit = (tile: TilesetTileNode): void => {
+    const props = tile.metadata?.properties;
+    if (props !== undefined) {
+      assignCount(counts, 'crossline', props['u_slices']);
+      assignCount(counts, 'inline', props['v_slices']);
+      assignCount(counts, 'depth', props['w_slices']);
+    }
+    for (const child of tile.children ?? []) {
+      visit(child);
+    }
+  };
+  visit(root);
+  return counts;
+};
+
+const assignCount = (
+  counts: Partial<Record<SeismicSliceAxis, number>>,
+  axis: SeismicSliceAxis,
+  value: unknown,
+): void => {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    counts[axis] = value;
+  }
+};
+
+const readSliceIdentity = (
+  tile: TilesetTileNode,
+): { direction: OgcSliceDirection; number: number } | null => {
+  const props = tile.metadata?.properties;
+  if (props === undefined) {
+    return null;
+  }
+  const direction = props['sliceDirection'];
+  const number = props['sliceNumber'];
+  if (!isOgcSliceDirection(direction) || typeof number !== 'number') {
+    return null;
+  }
+  return { direction, number };
+};
+
+export const parseSliceFromUri = (uri: string): number | null => {
+  const match = SLICE_URI_PATTERN.exec(uri);
+  return match === null ? null : Number(match[1]);
+};
+
+/**
+ * When only URI slice numbers exist, partition the sorted list using
+ * `u_slices` / `v_slices` / `w_slices` counts (crossline, then inline, then depth).
+ */
+const partitionUriSlicesByCounts = (
+  uriNumbers: number[],
+  counts: Partial<Record<SeismicSliceAxis, number>>,
+  target: Record<OgcSliceDirection, Set<number>>,
+): void => {
+  const sorted = [...new Set(uriNumbers)].sort((a, b) => a - b);
+  const uCount = counts.crossline;
+  const vCount = counts.inline;
+  const wCount = counts.depth;
+
+  if (
+    uCount === undefined ||
+    vCount === undefined ||
+    wCount === undefined ||
+    uCount + vCount + wCount !== sorted.length
+  ) {
+    // Counts missing or inconsistent — cannot safely assign axes.
+    return;
+  }
+
+  let offset = 0;
+  const assign = (axis: SeismicSliceAxis, count: number): void => {
+    const direction = AXIS_TO_DIRECTION[axis];
+    for (let i = 0; i < count; i++) {
+      target[direction].add(sorted[offset + i]);
+    }
+    offset += count;
+  };
+
+  assign('crossline', uCount);
+  assign('inline', vCount);
+  assign('depth', wCount);
+};
+
+export const readTileSliceKey = (
+  tile: TilesetTileNode,
+): { direction: OgcSliceDirection; number: number } | null => {
+  const fromMeta = readSliceIdentity(tile);
+  if (fromMeta !== null) {
+    return fromMeta;
+  }
+  return null;
+};
+
+export { DIRECTION_TO_AXIS };

--- a/ui/src/features/layer/slice/tileset-slice-metadata.ts
+++ b/ui/src/features/layer/slice/tileset-slice-metadata.ts
@@ -80,6 +80,20 @@ export const parseTilesetSliceMetadata = (
 
   if (!hasDirectionalMeta && uriOnlyNumbers.length > 0) {
     partitionUriSlicesByCounts(uriOnlyNumbers, counts, byDirection);
+  } else if (hasDirectionalMeta && uriOnlyNumbers.length > 0) {
+    // Mixed tileset: some tiles carry `sliceDirection`/`sliceNumber`
+    // metadata, others only have a `-slice-N.glb` URI. The count-based
+    // partition below assumes slice numbers are laid out in contiguous,
+    // sorted per-axis blocks across *all* slices — an assumption that only
+    // holds when none of them are already claimed via metadata. We cannot
+    // safely guess the axis of the remaining URI-only tiles here, so warn
+    // loudly (instead of silently dropping them) rather than risk assigning
+    // them to the wrong axis.
+    console.warn(
+      `[tileset-slice-metadata] ${uriOnlyNumbers.length} slice tile(s) have no ` +
+        'sliceDirection/sliceNumber metadata in a partially annotated tileset; ' +
+        'they cannot be safely assigned to an axis and will be omitted.',
+    );
   }
 
   const axes: Partial<Record<SeismicSliceAxis, TilesetSliceAxisInfo>> = {};
@@ -138,7 +152,11 @@ const readSliceIdentity = (
   }
   const direction = props['sliceDirection'];
   const number = props['sliceNumber'];
-  if (!isOgcSliceDirection(direction) || typeof number !== 'number') {
+  if (
+    !isOgcSliceDirection(direction) ||
+    typeof number !== 'number' ||
+    !Number.isInteger(number)
+  ) {
     return null;
   }
   return { direction, number };

--- a/ui/src/features/layer/slice/tileset-slice-prefetch.test.ts
+++ b/ui/src/features/layer/slice/tileset-slice-prefetch.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  collectAxisSliceUriMap,
+  emptySlicePreloadProgress,
+  orderNumbersFromCenter,
+  SlicePreloadQueue,
+} from './tileset-slice-prefetch';
+
+const tilesetJson = {
+  root: {
+    children: [
+      {
+        content: { uri: 'https://x/foo-3.glb' },
+        metadata: { properties: { sliceDirection: 'u', sliceNumber: 3 } },
+        children: [],
+      },
+      {
+        content: { uri: 'https://x/foo-7.glb' },
+        metadata: { properties: { sliceDirection: 'u', sliceNumber: 7 } },
+        children: [],
+      },
+      {
+        content: { uri: 'https://x/foo-3-v.glb' },
+        metadata: { properties: { sliceDirection: 'v', sliceNumber: 3 } },
+        children: [],
+      },
+    ],
+  },
+};
+
+describe('collectAxisSliceUriMap', () => {
+  it('maps every slice number on the axis to its content URI', () => {
+    const map = collectAxisSliceUriMap(tilesetJson, 'u');
+    expect(map.get(3)).toBe('https://x/foo-3.glb');
+    expect(map.get(7)).toBe('https://x/foo-7.glb');
+    expect(map.has(3) && map.size).toBe(2);
+  });
+});
+
+describe('orderNumbersFromCenter', () => {
+  it('orders slice numbers by distance from the center', () => {
+    expect(orderNumbersFromCenter([1, 10, 5, 6, 4], 5)).toEqual([
+      5, 4, 6, 1, 10,
+    ]);
+  });
+});
+
+describe('emptySlicePreloadProgress', () => {
+  it('starts idle with zeroed axis totals', () => {
+    const progress = emptySlicePreloadProgress();
+    expect(progress.status).toBe('idle');
+    expect(progress.loaded).toBe(0);
+    expect(progress.total).toBe(0);
+    expect(progress.axes.crossline).toEqual({ loaded: 0, total: 0 });
+  });
+});
+
+describe('SlicePreloadQueue', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('fetches enqueued URLs and reports progress up to done', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      blob: async () => new Blob(),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const progressUpdates: Array<{ loaded: number; total: number }> = [];
+    const queue = new SlicePreloadQueue({
+      onProgress: (progress) =>
+        progressUpdates.push({ loaded: progress.loaded, total: progress.total }),
+    });
+
+    queue.enqueue('crossline', ['https://x/a.glb', 'https://x/b.glb']);
+
+    await vi.waitFor(() => {
+      expect(queue.progress.status).toBe('done');
+    });
+
+    expect(queue.progress).toEqual({
+      status: 'done',
+      loaded: 2,
+      total: 2,
+      axes: {
+        crossline: { loaded: 2, total: 2 },
+        inline: { loaded: 0, total: 0 },
+        depth: { loaded: 0, total: 0 },
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not enqueue the same URL twice while pending/in-flight/completed', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      blob: async () => new Blob(),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const queue = new SlicePreloadQueue();
+    queue.enqueue('crossline', ['https://x/a.glb']);
+    queue.enqueue('crossline', ['https://x/a.glb']);
+
+    await vi.waitFor(() => {
+      expect(queue.progress.status).toBe('done');
+    });
+
+    expect(queue.progress.total).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a failed request up to the attempt cap, then counts it as done anyway', async () => {
+    let calls = 0;
+    const fetchMock = vi.fn(async () => {
+      calls += 1;
+      return { ok: false, blob: async () => new Blob() };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const queue = new SlicePreloadQueue();
+    queue.enqueue('inline', ['https://x/flaky.glb']);
+
+    await vi.waitFor(() => {
+      expect(queue.progress.status).toBe('done');
+    });
+
+    // 3 total attempts (1 initial + 2 retries), then given up on and still
+    // counted so overall progress can reach 100%.
+    expect(calls).toBe(3);
+    expect(queue.progress).toMatchObject({
+      status: 'done',
+      loaded: 1,
+      total: 1,
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Giving up prefetching'),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('aborts in-flight requests on abortAndClear()', async () => {
+    const fetchMock = vi.fn(
+      (_url: string, init: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          init.signal.addEventListener('abort', () => {
+            reject(new DOMException('Aborted', 'AbortError'));
+          });
+        }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const queue = new SlicePreloadQueue();
+    queue.enqueue('depth', ['https://x/slow.glb']);
+    queue.abortAndClear();
+
+    // Give the aborted worker a tick to settle; it must not throw or hang.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(queue.progress.status).not.toBe('done');
+  });
+});

--- a/ui/src/features/layer/slice/tileset-slice-prefetch.test.ts
+++ b/ui/src/features/layer/slice/tileset-slice-prefetch.test.ts
@@ -71,7 +71,10 @@ describe('SlicePreloadQueue', () => {
     const progressUpdates: Array<{ loaded: number; total: number }> = [];
     const queue = new SlicePreloadQueue({
       onProgress: (progress) =>
-        progressUpdates.push({ loaded: progress.loaded, total: progress.total }),
+        progressUpdates.push({
+          loaded: progress.loaded,
+          total: progress.total,
+        }),
     });
 
     queue.enqueue('crossline', ['https://x/a.glb', 'https://x/b.glb']);

--- a/ui/src/features/layer/slice/tileset-slice-prefetch.ts
+++ b/ui/src/features/layer/slice/tileset-slice-prefetch.ts
@@ -3,10 +3,7 @@ import {
   SeismicSliceAxis,
   SEISMIC_SLICE_AXES,
 } from 'src/features/layer/slice/tiles3d-slice.types';
-import {
-  parseSliceFromUri,
-  readTileSliceKey,
-} from 'src/features/layer/slice/tileset-slice-metadata';
+import { resolveSliceIdentity } from 'src/features/layer/slice/tileset-slice-metadata';
 
 interface TilesetTileNode {
   content?: { uri?: string };
@@ -56,44 +53,6 @@ const toAbsoluteUri = (uri: string, baseUrl: string): string => {
 };
 
 /**
- * Collect absolute content URIs for the given axis direction + slice numbers.
- */
-export const collectSliceContentUris = (
-  tilesetJson: unknown,
-  direction: OgcSliceDirection,
-  numbers: ReadonlySet<number>,
-  baseUrl = '',
-): string[] => {
-  if (tilesetJson === null || typeof tilesetJson !== 'object') {
-    return [];
-  }
-  const root = (tilesetJson as TilesetJson).root;
-  if (root === undefined) {
-    return [];
-  }
-
-  const uris: string[] = [];
-  const visit = (tile: TilesetTileNode): void => {
-    const uri = tile.content?.uri;
-    if (uri !== undefined && uri !== '') {
-      const identity = resolveIdentity(tile, uri);
-      if (
-        identity !== null &&
-        numbers.has(identity.number) &&
-        (identity.direction === null || identity.direction === direction)
-      ) {
-        uris.push(toAbsoluteUri(uri, baseUrl));
-      }
-    }
-    for (const child of tile.children ?? []) {
-      visit(child);
-    }
-  };
-  visit(root);
-  return [...new Set(uris)];
-};
-
-/**
  * Collect every content URI on an axis, keyed by slice number.
  */
 export const collectAxisSliceUriMap = (
@@ -113,7 +72,7 @@ export const collectAxisSliceUriMap = (
   const visit = (tile: TilesetTileNode): void => {
     const uri = tile.content?.uri;
     if (uri !== undefined && uri !== '') {
-      const identity = resolveIdentity(tile, uri);
+      const identity = resolveSliceIdentity(tile, uri);
       if (
         identity !== null &&
         (identity.direction === null || identity.direction === direction)
@@ -141,25 +100,44 @@ export const orderNumbersFromCenter = (
     (a, b) => Math.abs(a - center) - Math.abs(b - center) || a - b,
   );
 
-const resolveIdentity = (
-  tile: TilesetTileNode,
-  uri: string,
-): { direction: OgcSliceDirection | null; number: number } | null => {
-  const fromMeta = readTileSliceKey(tile);
-  if (fromMeta !== null) {
-    return fromMeta;
-  }
-  const fromUri = parseSliceFromUri(uri);
-  if (fromUri === null) {
-    return null;
-  }
-  return { direction: null, number: fromUri };
-};
-
 interface PrefetchJob {
   url: string;
   axis: SeismicSliceAxis;
+  /** Number of fetch attempts already made for this job. */
+  attempts: number;
 }
+
+/**
+ * Give up on a single prefetch request rather than tie up a worker slot
+ * indefinitely — this is background cache warming, not a user-blocking load.
+ */
+const SLICE_PREFETCH_REQUEST_TIMEOUT_MS = 20_000;
+
+/**
+ * Retry a failed prefetch request up to this many times (in total) before
+ * giving up on it for good. Failures here are typically transient (flaky
+ * network, temporary gateway errors), and without a retry a single failure
+ * used to permanently stall progress below 100%.
+ */
+const SLICE_PREFETCH_MAX_ATTEMPTS = 3;
+
+/**
+ * Abort `target` whenever `source` aborts. Manual wiring instead of
+ * `AbortSignal.any([source, target.signal])`, which is unavailable in older
+ * targeted browsers (see AGENTS.md: Edge 18 is a supported target).
+ */
+const forwardAbort = (
+  source: AbortSignal,
+  target: AbortController,
+): (() => void) => {
+  if (source.aborted) {
+    target.abort();
+    return () => {};
+  }
+  const onAbort = (): void => target.abort();
+  source.addEventListener('abort', onAbort, { once: true });
+  return () => source.removeEventListener('abort', onAbort);
+};
 
 /**
  * Background HTTP cache warmer with optional progress + a mutable priority
@@ -248,7 +226,7 @@ export class SlicePreloadQueue {
         this.queuedUrls.add(url);
         this.axisTotals[axis] += 1;
       }
-      fresh.push({ url, axis });
+      fresh.push({ url, axis, attempts: 0 });
     }
     if (fresh.length === 0) {
       this.emitProgress();
@@ -293,6 +271,17 @@ export class SlicePreloadQueue {
         }
         this.pendingUrls.delete(job.url);
         this.inFlightUrls.add(job.url);
+
+        // Bound each request individually so a single hung request cannot
+        // tie up a worker slot (and thus this job's URL) indefinitely, while
+        // still honouring abortAndClear() via the outer `signal`.
+        const requestController = new AbortController();
+        const removeAbortForwarding = forwardAbort(signal, requestController);
+        const timeoutId = setTimeout(
+          () => requestController.abort(),
+          SLICE_PREFETCH_REQUEST_TIMEOUT_MS,
+        );
+
         let isFetched = false;
         try {
           const response = await fetch(job.url, {
@@ -300,7 +289,7 @@ export class SlicePreloadQueue {
             headers,
             mode: 'cors',
             credentials: 'omit',
-            signal,
+            signal: requestController.signal,
             cache: 'force-cache',
           });
           if (response.ok) {
@@ -309,15 +298,42 @@ export class SlicePreloadQueue {
           }
         } catch {
           if (signal.aborted) {
+            clearTimeout(timeoutId);
+            removeAbortForwarding();
             this.inFlightUrls.delete(job.url);
             return;
           }
+        } finally {
+          clearTimeout(timeoutId);
+          removeAbortForwarding();
         }
+
         this.inFlightUrls.delete(job.url);
-        if (isFetched && !this.completedUrls.has(job.url)) {
-          this.completedUrls.add(job.url);
-          this.axisLoaded[job.axis] += 1;
-          this.emitProgress();
+        if (isFetched) {
+          if (!this.completedUrls.has(job.url)) {
+            this.completedUrls.add(job.url);
+            this.axisLoaded[job.axis] += 1;
+            this.emitProgress();
+          }
+          continue;
+        }
+
+        // Failed (network error, non-OK response, or per-request timeout):
+        // retry a bounded number of times before giving up. Without this, a
+        // single transient failure permanently stalled overall progress
+        // below 100%, since this URL would never be counted either way.
+        if (job.attempts + 1 < SLICE_PREFETCH_MAX_ATTEMPTS) {
+          this.pendingUrls.add(job.url);
+          this.pending.push({ ...job, attempts: job.attempts + 1 });
+        } else {
+          console.warn(
+            `Giving up prefetching ${job.url} after ${SLICE_PREFETCH_MAX_ATTEMPTS} attempts`,
+          );
+          if (!this.completedUrls.has(job.url)) {
+            this.completedUrls.add(job.url);
+            this.axisLoaded[job.axis] += 1;
+            this.emitProgress();
+          }
         }
       }
     };
@@ -341,67 +357,3 @@ export class SlicePreloadQueue {
     this.options.onProgress?.(this.progress);
   }
 }
-
-/**
- * Warm the browser HTTP cache for nearby slice GLBs without attaching Cesium
- * tilesets. Limited concurrency; cancellable via AbortSignal.
- */
-export const prefetchUrls = async (
-  urls: readonly string[],
-  options: {
-    concurrency?: number;
-    signal?: AbortSignal;
-    headers?: Record<string, string>;
-    onProgress?: (done: number, total: number) => void;
-  } = {},
-): Promise<void> => {
-  const concurrency = Math.max(
-    1,
-    options.concurrency ?? SLICE_PREFETCH_CONCURRENCY,
-  );
-  const headers = options.headers ?? {};
-  const signal = options.signal;
-  let nextIndex = 0;
-  let done = 0;
-  const total = urls.length;
-  options.onProgress?.(0, total);
-
-  const worker = async (): Promise<void> => {
-    while (nextIndex < urls.length) {
-      if (signal?.aborted) {
-        return;
-      }
-      const index = nextIndex;
-      nextIndex += 1;
-      const url = urls[index];
-      try {
-        await fetch(url, {
-          method: 'GET',
-          headers,
-          mode: 'cors',
-          credentials: 'omit',
-          signal,
-          cache: 'force-cache',
-        });
-      } catch {
-        if (signal?.aborted) {
-          return;
-        }
-      }
-      done += 1;
-      options.onProgress?.(done, total);
-    }
-  };
-
-  const workers = Array.from(
-    { length: Math.min(concurrency, urls.length || 1) },
-    () => worker(),
-  );
-  await Promise.all(workers);
-};
-
-export type PrefetchAxisRequest = {
-  axis: SeismicSliceAxis;
-  direction: OgcSliceDirection;
-  numbers: readonly number[];
-};

--- a/ui/src/features/layer/slice/tileset-slice-prefetch.ts
+++ b/ui/src/features/layer/slice/tileset-slice-prefetch.ts
@@ -1,0 +1,391 @@
+import {
+  OgcSliceDirection,
+  SeismicSliceAxis,
+  SEISMIC_SLICE_AXES,
+} from 'src/features/layer/slice/tiles3d-slice.types';
+import {
+  parseSliceFromUri,
+  readTileSliceKey,
+} from 'src/features/layer/slice/tileset-slice-metadata';
+
+interface TilesetTileNode {
+  content?: { uri?: string };
+  children?: TilesetTileNode[];
+  metadata?: {
+    class?: string;
+    properties?: Record<string, unknown>;
+  };
+}
+
+interface TilesetJson {
+  root?: TilesetTileNode;
+}
+
+export const SLICE_PREFETCH_CONCURRENCY = 6;
+
+export interface SliceAxisPreloadProgress {
+  loaded: number;
+  total: number;
+}
+
+export interface SlicePreloadProgress {
+  status: 'idle' | 'loading' | 'done';
+  loaded: number;
+  total: number;
+  axes: Record<SeismicSliceAxis, SliceAxisPreloadProgress>;
+}
+
+export const emptySlicePreloadProgress = (): SlicePreloadProgress => ({
+  status: 'idle',
+  loaded: 0,
+  total: 0,
+  axes: {
+    crossline: { loaded: 0, total: 0 },
+    inline: { loaded: 0, total: 0 },
+    depth: { loaded: 0, total: 0 },
+  },
+});
+
+/**
+ * Collect absolute content URIs for the given axis direction + slice numbers.
+ */
+export const collectSliceContentUris = (
+  tilesetJson: unknown,
+  direction: OgcSliceDirection,
+  numbers: ReadonlySet<number>,
+): string[] => {
+  if (tilesetJson === null || typeof tilesetJson !== 'object') {
+    return [];
+  }
+  const root = (tilesetJson as TilesetJson).root;
+  if (root === undefined) {
+    return [];
+  }
+
+  const uris: string[] = [];
+  const visit = (tile: TilesetTileNode): void => {
+    const uri = tile.content?.uri;
+    if (uri !== undefined && uri !== '') {
+      const identity = resolveIdentity(tile, uri);
+      if (
+        identity !== null &&
+        numbers.has(identity.number) &&
+        (identity.direction === null || identity.direction === direction)
+      ) {
+        uris.push(uri);
+      }
+    }
+    for (const child of tile.children ?? []) {
+      visit(child);
+    }
+  };
+  visit(root);
+  return [...new Set(uris)];
+};
+
+/**
+ * Collect every content URI on an axis, keyed by slice number.
+ */
+export const collectAxisSliceUriMap = (
+  tilesetJson: unknown,
+  direction: OgcSliceDirection,
+): Map<number, string> => {
+  const map = new Map<number, string>();
+  if (tilesetJson === null || typeof tilesetJson !== 'object') {
+    return map;
+  }
+  const root = (tilesetJson as TilesetJson).root;
+  if (root === undefined) {
+    return map;
+  }
+
+  const visit = (tile: TilesetTileNode): void => {
+    const uri = tile.content?.uri;
+    if (uri !== undefined && uri !== '') {
+      const identity = resolveIdentity(tile, uri);
+      if (
+        identity !== null &&
+        (identity.direction === null || identity.direction === direction)
+      ) {
+        map.set(identity.number, uri);
+      }
+    }
+    for (const child of tile.children ?? []) {
+      visit(child);
+    }
+  };
+  visit(root);
+  return map;
+};
+
+/**
+ * Order slice numbers by distance from `center` so the current slider
+ * neighborhood is warmed first.
+ */
+export const orderNumbersFromCenter = (
+  numbers: readonly number[],
+  center: number,
+): number[] =>
+  [...numbers].sort(
+    (a, b) => Math.abs(a - center) - Math.abs(b - center) || a - b,
+  );
+
+const resolveIdentity = (
+  tile: TilesetTileNode,
+  uri: string,
+): { direction: OgcSliceDirection | null; number: number } | null => {
+  const fromMeta = readTileSliceKey(tile);
+  if (fromMeta !== null) {
+    return fromMeta;
+  }
+  const fromUri = parseSliceFromUri(uri);
+  if (fromUri === null) {
+    return null;
+  }
+  return { direction: null, number: fromUri };
+};
+
+interface PrefetchJob {
+  url: string;
+  axis: SeismicSliceAxis;
+}
+
+/**
+ * Background HTTP cache warmer with optional progress + a mutable priority
+ * front-queue (used when the user scrubs a slider).
+ */
+export class SlicePreloadQueue {
+  private readonly pending: PrefetchJob[] = [];
+  private readonly pendingUrls = new Set<string>();
+  private readonly inFlightUrls = new Set<string>();
+  private readonly completedUrls = new Set<string>();
+  /**
+   * Every URL that has ever been counted towards `axisTotals`, kept across
+   * pause/resume (unlike `pendingUrls`/`inFlightUrls`, which are cleared by
+   * `abortAndClear`). Without this, re-enqueuing the same not-yet-finished
+   * URLs after reopening the HUD would double-count them into the total,
+   * permanently inflating the denominator so progress never reaches 100%.
+   */
+  private readonly queuedUrls = new Set<string>();
+  private readonly axisTotals: Record<SeismicSliceAxis, number> = {
+    crossline: 0,
+    inline: 0,
+    depth: 0,
+  };
+  private readonly axisLoaded: Record<SeismicSliceAxis, number> = {
+    crossline: 0,
+    inline: 0,
+    depth: 0,
+  };
+  private running = false;
+  private abort: AbortController | null = null;
+
+  constructor(
+    private readonly options: {
+      concurrency?: number;
+      headers?: Record<string, string>;
+      onProgress?: (progress: SlicePreloadProgress) => void;
+    } = {},
+  ) {}
+
+  get progress(): SlicePreloadProgress {
+    const loaded = SEISMIC_SLICE_AXES.reduce(
+      (sum, axis) => sum + this.axisLoaded[axis],
+      0,
+    );
+    const total = SEISMIC_SLICE_AXES.reduce(
+      (sum, axis) => sum + this.axisTotals[axis],
+      0,
+    );
+    const axes = Object.fromEntries(
+      SEISMIC_SLICE_AXES.map((axis) => [
+        axis,
+        { loaded: this.axisLoaded[axis], total: this.axisTotals[axis] },
+      ]),
+    ) as Record<SeismicSliceAxis, SliceAxisPreloadProgress>;
+
+    let status: SlicePreloadProgress['status'] = 'idle';
+    if (total > 0 && loaded >= total) {
+      status = 'done';
+    } else if (total > 0) {
+      status = 'loading';
+    }
+
+    return { status, loaded, total, axes };
+  }
+
+  /**
+   * Enqueue URLs for an axis (skips already completed / pending / in-flight).
+   * `priority` inserts at the front of the queue.
+   */
+  enqueue(
+    axis: SeismicSliceAxis,
+    urls: readonly string[],
+    priority = false,
+  ): void {
+    const fresh: PrefetchJob[] = [];
+    for (const url of urls) {
+      if (
+        this.completedUrls.has(url) ||
+        this.pendingUrls.has(url) ||
+        this.inFlightUrls.has(url)
+      ) {
+        continue;
+      }
+      this.pendingUrls.add(url);
+      if (!this.queuedUrls.has(url)) {
+        this.queuedUrls.add(url);
+        this.axisTotals[axis] += 1;
+      }
+      fresh.push({ url, axis });
+    }
+    if (fresh.length === 0) {
+      this.emitProgress();
+      return;
+    }
+    if (priority) {
+      this.pending.unshift(...fresh);
+    } else {
+      this.pending.push(...fresh);
+    }
+    this.emitProgress();
+    this.ensureRunning();
+  }
+
+  abortAndClear(): void {
+    this.abort?.abort();
+    this.abort = null;
+    this.running = false;
+    this.pending.length = 0;
+    this.pendingUrls.clear();
+    this.inFlightUrls.clear();
+  }
+
+  private ensureRunning(): void {
+    if (this.running) {
+      return;
+    }
+    this.running = true;
+    this.abort = new AbortController();
+    const signal = this.abort.signal;
+    const concurrency = Math.max(
+      1,
+      this.options.concurrency ?? SLICE_PREFETCH_CONCURRENCY,
+    );
+    const headers = this.options.headers ?? {};
+
+    const worker = async (): Promise<void> => {
+      while (!signal.aborted) {
+        const job = this.pending.shift();
+        if (job === undefined) {
+          return;
+        }
+        this.pendingUrls.delete(job.url);
+        this.inFlightUrls.add(job.url);
+        try {
+          await fetch(job.url, {
+            method: 'GET',
+            headers,
+            mode: 'cors',
+            credentials: 'omit',
+            signal,
+            cache: 'force-cache',
+          });
+        } catch {
+          if (signal.aborted) {
+            this.inFlightUrls.delete(job.url);
+            return;
+          }
+        }
+        this.inFlightUrls.delete(job.url);
+        if (!this.completedUrls.has(job.url)) {
+          this.completedUrls.add(job.url);
+          this.axisLoaded[job.axis] += 1;
+          this.emitProgress();
+        }
+      }
+    };
+
+    void Promise.all(
+      Array.from({ length: concurrency }, () => worker()),
+    ).finally(() => {
+      if (this.abort?.signal === signal) {
+        this.running = false;
+        this.abort = null;
+        if (this.pending.length > 0) {
+          this.ensureRunning();
+        } else {
+          this.emitProgress();
+        }
+      }
+    });
+  }
+
+  private emitProgress(): void {
+    this.options.onProgress?.(this.progress);
+  }
+}
+
+/**
+ * Warm the browser HTTP cache for nearby slice GLBs without attaching Cesium
+ * tilesets. Limited concurrency; cancellable via AbortSignal.
+ */
+export const prefetchUrls = async (
+  urls: readonly string[],
+  options: {
+    concurrency?: number;
+    signal?: AbortSignal;
+    headers?: Record<string, string>;
+    onProgress?: (done: number, total: number) => void;
+  } = {},
+): Promise<void> => {
+  const concurrency = Math.max(
+    1,
+    options.concurrency ?? SLICE_PREFETCH_CONCURRENCY,
+  );
+  const headers = options.headers ?? {};
+  const signal = options.signal;
+  let nextIndex = 0;
+  let done = 0;
+  const total = urls.length;
+  options.onProgress?.(0, total);
+
+  const worker = async (): Promise<void> => {
+    while (nextIndex < urls.length) {
+      if (signal?.aborted) {
+        return;
+      }
+      const index = nextIndex;
+      nextIndex += 1;
+      const url = urls[index];
+      try {
+        await fetch(url, {
+          method: 'GET',
+          headers,
+          mode: 'cors',
+          credentials: 'omit',
+          signal,
+          cache: 'force-cache',
+        });
+      } catch {
+        if (signal?.aborted) {
+          return;
+        }
+      }
+      done += 1;
+      options.onProgress?.(done, total);
+    }
+  };
+
+  const workers = Array.from(
+    { length: Math.min(concurrency, urls.length || 1) },
+    () => worker(),
+  );
+  await Promise.all(workers);
+};
+
+export type PrefetchAxisRequest = {
+  axis: SeismicSliceAxis;
+  direction: OgcSliceDirection;
+  numbers: readonly number[];
+};

--- a/ui/src/features/layer/slice/tileset-slice-prefetch.ts
+++ b/ui/src/features/layer/slice/tileset-slice-prefetch.ts
@@ -250,6 +250,75 @@ export class SlicePreloadQueue {
     this.inFlightUrls.clear();
   }
 
+  /**
+   * Fetch a single job's URL, bounding it with its own abort controller/timeout
+   * so a hung request cannot tie up a worker slot indefinitely, while still
+   * honouring `abortAndClear()` via the outer `signal`.
+   *
+   * Returns `'aborted'` if the outer signal was aborted while fetching (the
+   * caller must stop its loop), `'fetched'` on success, or `'failed'`
+   * otherwise (network error, non-OK response, or per-request timeout).
+   */
+  private async runJob(
+    job: PrefetchJob,
+    signal: AbortSignal,
+    headers: Record<string, string>,
+  ): Promise<'fetched' | 'failed' | 'aborted'> {
+    const requestController = new AbortController();
+    const removeAbortForwarding = forwardAbort(signal, requestController);
+    const timeoutId = setTimeout(
+      () => requestController.abort(),
+      SLICE_PREFETCH_REQUEST_TIMEOUT_MS,
+    );
+    try {
+      const response = await fetch(job.url, {
+        method: 'GET',
+        headers,
+        mode: 'cors',
+        credentials: 'omit',
+        signal: requestController.signal,
+        cache: 'force-cache',
+      });
+      if (!response.ok) {
+        return 'failed';
+      }
+      await response.blob();
+      return 'fetched';
+    } catch {
+      return signal.aborted ? 'aborted' : 'failed';
+    } finally {
+      clearTimeout(timeoutId);
+      removeAbortForwarding();
+    }
+  }
+
+  /** Mark a job's URL as completed, updating progress at most once per URL. */
+  private markJobCompleted(job: PrefetchJob): void {
+    if (this.completedUrls.has(job.url)) {
+      return;
+    }
+    this.completedUrls.add(job.url);
+    this.axisLoaded[job.axis] += 1;
+    this.emitProgress();
+  }
+
+  /**
+   * Requeue a failed job for another attempt, or give up on it for good.
+   * Without this, a single transient failure (flaky network, temporary
+   * gateway error) used to permanently stall overall progress below 100%.
+   */
+  private requeueOrGiveUp(job: PrefetchJob): void {
+    if (job.attempts + 1 < SLICE_PREFETCH_MAX_ATTEMPTS) {
+      this.pendingUrls.add(job.url);
+      this.pending.push({ ...job, attempts: job.attempts + 1 });
+      return;
+    }
+    console.warn(
+      `Giving up prefetching ${job.url} after ${SLICE_PREFETCH_MAX_ATTEMPTS} attempts`,
+    );
+    this.markJobCompleted(job);
+  }
+
   private ensureRunning(): void {
     if (this.running) {
       return;
@@ -272,69 +341,17 @@ export class SlicePreloadQueue {
         this.pendingUrls.delete(job.url);
         this.inFlightUrls.add(job.url);
 
-        // Bound each request individually so a single hung request cannot
-        // tie up a worker slot (and thus this job's URL) indefinitely, while
-        // still honouring abortAndClear() via the outer `signal`.
-        const requestController = new AbortController();
-        const removeAbortForwarding = forwardAbort(signal, requestController);
-        const timeoutId = setTimeout(
-          () => requestController.abort(),
-          SLICE_PREFETCH_REQUEST_TIMEOUT_MS,
-        );
-
-        let isFetched = false;
-        try {
-          const response = await fetch(job.url, {
-            method: 'GET',
-            headers,
-            mode: 'cors',
-            credentials: 'omit',
-            signal: requestController.signal,
-            cache: 'force-cache',
-          });
-          if (response.ok) {
-            await response.blob();
-            isFetched = true;
-          }
-        } catch {
-          if (signal.aborted) {
-            clearTimeout(timeoutId);
-            removeAbortForwarding();
-            this.inFlightUrls.delete(job.url);
-            return;
-          }
-        } finally {
-          clearTimeout(timeoutId);
-          removeAbortForwarding();
-        }
-
+        const result = await this.runJob(job, signal, headers);
         this.inFlightUrls.delete(job.url);
-        if (isFetched) {
-          if (!this.completedUrls.has(job.url)) {
-            this.completedUrls.add(job.url);
-            this.axisLoaded[job.axis] += 1;
-            this.emitProgress();
-          }
+
+        if (result === 'aborted') {
+          return;
+        }
+        if (result === 'fetched') {
+          this.markJobCompleted(job);
           continue;
         }
-
-        // Failed (network error, non-OK response, or per-request timeout):
-        // retry a bounded number of times before giving up. Without this, a
-        // single transient failure permanently stalled overall progress
-        // below 100%, since this URL would never be counted either way.
-        if (job.attempts + 1 < SLICE_PREFETCH_MAX_ATTEMPTS) {
-          this.pendingUrls.add(job.url);
-          this.pending.push({ ...job, attempts: job.attempts + 1 });
-        } else {
-          console.warn(
-            `Giving up prefetching ${job.url} after ${SLICE_PREFETCH_MAX_ATTEMPTS} attempts`,
-          );
-          if (!this.completedUrls.has(job.url)) {
-            this.completedUrls.add(job.url);
-            this.axisLoaded[job.axis] += 1;
-            this.emitProgress();
-          }
-        }
+        this.requeueOrGiveUp(job);
       }
     };
 

--- a/ui/src/features/layer/slice/tileset-slice-prefetch.ts
+++ b/ui/src/features/layer/slice/tileset-slice-prefetch.ts
@@ -46,6 +46,15 @@ export const emptySlicePreloadProgress = (): SlicePreloadProgress => ({
   },
 });
 
+const toAbsoluteUri = (uri: string, baseUrl: string): string => {
+  if (!baseUrl) return uri;
+  try {
+    return new URL(uri, baseUrl).href;
+  } catch {
+    return uri;
+  }
+};
+
 /**
  * Collect absolute content URIs for the given axis direction + slice numbers.
  */
@@ -53,6 +62,7 @@ export const collectSliceContentUris = (
   tilesetJson: unknown,
   direction: OgcSliceDirection,
   numbers: ReadonlySet<number>,
+  baseUrl = '',
 ): string[] => {
   if (tilesetJson === null || typeof tilesetJson !== 'object') {
     return [];
@@ -72,7 +82,7 @@ export const collectSliceContentUris = (
         numbers.has(identity.number) &&
         (identity.direction === null || identity.direction === direction)
       ) {
-        uris.push(uri);
+        uris.push(toAbsoluteUri(uri, baseUrl));
       }
     }
     for (const child of tile.children ?? []) {
@@ -89,6 +99,7 @@ export const collectSliceContentUris = (
 export const collectAxisSliceUriMap = (
   tilesetJson: unknown,
   direction: OgcSliceDirection,
+  baseUrl = '',
 ): Map<number, string> => {
   const map = new Map<number, string>();
   if (tilesetJson === null || typeof tilesetJson !== 'object') {
@@ -107,7 +118,7 @@ export const collectAxisSliceUriMap = (
         identity !== null &&
         (identity.direction === null || identity.direction === direction)
       ) {
-        map.set(identity.number, uri);
+        map.set(identity.number, toAbsoluteUri(uri, baseUrl));
       }
     }
     for (const child of tile.children ?? []) {
@@ -282,8 +293,9 @@ export class SlicePreloadQueue {
         }
         this.pendingUrls.delete(job.url);
         this.inFlightUrls.add(job.url);
+        let isFetched = false;
         try {
-          await fetch(job.url, {
+          const response = await fetch(job.url, {
             method: 'GET',
             headers,
             mode: 'cors',
@@ -291,6 +303,10 @@ export class SlicePreloadQueue {
             signal,
             cache: 'force-cache',
           });
+          if (response.ok) {
+            await response.blob();
+            isFetched = true;
+          }
         } catch {
           if (signal.aborted) {
             this.inFlightUrls.delete(job.url);
@@ -298,7 +314,7 @@ export class SlicePreloadQueue {
           }
         }
         this.inFlightUrls.delete(job.url);
-        if (!this.completedUrls.has(job.url)) {
+        if (isFetched && !this.completedUrls.has(job.url)) {
           this.completedUrls.add(job.url);
           this.axisLoaded[job.axis] += 1;
           this.emitProgress();

--- a/ui/src/features/layer/slice/tileset-slice-prune.test.ts
+++ b/ui/src/features/layer/slice/tileset-slice-prune.test.ts
@@ -109,4 +109,37 @@ describe('pruneTilesetToSlices', () => {
       region: [0, 0, 1, 1, -100, 100],
     });
   });
+
+  it('leaves a kept parent volume alone when the parent also has its own content', () => {
+    const withOwnContent = {
+      root: {
+        // Root keeps both its own content *and* a child (ADD refinement).
+        // Its bounding volume is intentionally larger than the child's so it
+        // still covers the root's own geometry too.
+        boundingVolume: { region: [0, 0, 1, 1, -100, 100] },
+        geometricError: 10,
+        content: { uri: 'seismic-slice-X-0.glb' },
+        children: [
+          {
+            boundingVolume: { region: [0.2, 0.2, 0.4, 0.4, -10, 10] },
+            geometricError: 0,
+            content: { uri: 'seismic-slice-X-1.glb' },
+          },
+        ],
+      },
+    };
+    const out = pruneTilesetToSlices(
+      withOwnContent,
+      { numbers: new Set([0, 1]) },
+      'https://example.com/base/',
+    );
+    expect(out.root!.content!.uri).toBe(
+      'https://example.com/base/seismic-slice-X-0.glb',
+    );
+    // The root's own bounding volume must not shrink to the child-only
+    // union — that would cull the root's own kept content.
+    expect(out.root!.boundingVolume).toEqual({
+      region: [0, 0, 1, 1, -100, 100],
+    });
+  });
 });

--- a/ui/src/features/layer/slice/tileset-slice-prune.test.ts
+++ b/ui/src/features/layer/slice/tileset-slice-prune.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { pruneTilesetToSlices } from 'src/features/layer/slice/tileset-slice-prune';
+
+const json = {
+  asset: { version: '1.1' },
+  geometricError: 500,
+  root: {
+    boundingVolume: { region: [0, 0, 1, 1, -100, 100] },
+    geometricError: 250,
+    refine: 'ADD',
+    transform: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+    children: [
+      {
+        boundingVolume: { region: [0, 0, 0.5, 1, -100, 0] },
+        geometricError: 0,
+        content: { uri: 'seismic-slice-X-1.glb' },
+      },
+      {
+        boundingVolume: { region: [0.5, 0, 1, 1, -50, 100] },
+        geometricError: 0,
+        content: { uri: 'seismic-slice-X-2.glb' },
+      },
+      {
+        boundingVolume: { region: [0, 0, 1, 1, -100, 100] },
+        geometricError: 10,
+        children: [
+          {
+            boundingVolume: { region: [0.2, 0.2, 0.4, 0.4, -10, 10] },
+            geometricError: 0,
+            content: { uri: 'seismic-slice-X-3.glb' },
+          },
+        ],
+      },
+    ],
+  },
+};
+
+describe('pruneTilesetToSlices', () => {
+  it('keeps only selected slices and does not mutate the source', () => {
+    const before = structuredClone(json);
+    const out = pruneTilesetToSlices(
+      json,
+      { numbers: new Set([2]) },
+      'https://example.com/base/',
+    );
+    expect(json).toEqual(before);
+    expect(out.asset).toEqual({ version: '1.1' });
+    expect(out.geometricError).toBe(500);
+    expect(out.root!.transform).toEqual(json.root.transform);
+    expect(out.root!.children).toHaveLength(1);
+    expect(out.root!.children![0].content!.uri).toBe(
+      'https://example.com/base/seismic-slice-X-2.glb',
+    );
+    expect(out.root!.boundingVolume).toEqual({
+      region: [0.5, 0, 1, 1, -50, 100],
+    });
+  });
+
+  it('keeps nested slices and unions bounds', () => {
+    const out = pruneTilesetToSlices(
+      json,
+      { numbers: new Set([1, 3]) },
+      'https://example.com/base/',
+    );
+    expect(out.root!.children).toHaveLength(2);
+    const nested = out.root!.children![1];
+    expect(nested.children).toHaveLength(1);
+    expect(nested.content).toBeUndefined();
+    expect(nested.boundingVolume).toEqual({
+      region: [0.2, 0.2, 0.4, 0.4, -10, 10],
+    });
+    expect(out.root!.boundingVolume).toEqual({
+      region: [0, 0, 0.5, 1, -100, 10],
+    });
+  });
+
+  it('throws when nothing matches', () => {
+    expect(() =>
+      pruneTilesetToSlices(json, { numbers: new Set([99]) }, 'https://e.com/'),
+    ).toThrow();
+  });
+
+  it('leaves the parent volume alone when a kept child has no region', () => {
+    const mixed = {
+      root: {
+        boundingVolume: { region: [0, 0, 1, 1, -100, 100] },
+        geometricError: 10,
+        children: [
+          {
+            boundingVolume: { region: [0, 0, 0.5, 1, -100, 0] },
+            geometricError: 0,
+            content: { uri: 'seismic-slice-X-1.glb' },
+          },
+          {
+            boundingVolume: { box: [0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1] },
+            geometricError: 0,
+            content: { uri: 'seismic-slice-X-2.glb' },
+          },
+        ],
+      },
+    };
+    const out = pruneTilesetToSlices(
+      mixed,
+      { numbers: new Set([1, 2]) },
+      'https://example.com/base/',
+    );
+    expect(out.root!.children).toHaveLength(2);
+    expect(out.root!.boundingVolume).toEqual({
+      region: [0, 0, 1, 1, -100, 100],
+    });
+  });
+});

--- a/ui/src/features/layer/slice/tileset-slice-prune.ts
+++ b/ui/src/features/layer/slice/tileset-slice-prune.ts
@@ -108,7 +108,10 @@ const tightenBoundingVolumes = (tile: TilesetTileNode): void => {
       childRegions.every((region): region is number[] => region !== null)
     ) {
       tile.boundingVolume = {
-        region: childRegions.reduce((acc, region) => unionRegions(acc, region)),
+        region: childRegions.reduce(
+          (acc, region) => unionRegions(acc, region),
+          childRegions[0],
+        ),
       };
     }
   }

--- a/ui/src/features/layer/slice/tileset-slice-prune.ts
+++ b/ui/src/features/layer/slice/tileset-slice-prune.ts
@@ -1,0 +1,205 @@
+import { Resource } from 'cesium';
+import { OgcSliceDirection } from 'src/features/layer/slice/tiles3d-slice.types';
+import {
+  parseSliceFromUri,
+  readTileSliceKey,
+} from 'src/features/layer/slice/tileset-slice-metadata';
+
+interface TilesetTileNode {
+  content?: { uri?: string };
+  children?: TilesetTileNode[];
+  metadata?: {
+    class?: string;
+    properties?: Record<string, unknown>;
+  };
+  [key: string]: unknown;
+}
+
+interface TilesetJson {
+  root?: TilesetTileNode;
+  [key: string]: unknown;
+}
+
+export type SliceKeepSelector = {
+  /** When set, only tiles matching this direction are eligible. */
+  direction?: OgcSliceDirection;
+  numbers: ReadonlySet<number>;
+};
+
+/**
+ * Build a tileset JSON containing only the tiles whose slice identity is in
+ * `keep`. Content URIs are rewritten to absolute URLs so blob-based roots
+ * still resolve against the OGC base.
+ *
+ * Nodes are copied on keep rather than deep-cloning the whole document up
+ * front: a single slice keeps a handful of nodes out of potentially thousands,
+ * and this runs on every slider step.
+ */
+export const pruneTilesetToSlices = (
+  original: unknown,
+  keep: SliceKeepSelector,
+  baseUrl: string,
+): TilesetJson => {
+  if (original === null || typeof original !== 'object') {
+    throw new Error('Tileset JSON has no root.');
+  }
+  const source = original as TilesetJson;
+  if (source.root === undefined) {
+    throw new Error('Tileset JSON has no root.');
+  }
+
+  const prune = (tile: TilesetTileNode): TilesetTileNode | null => {
+    let shouldKeepTile = false;
+    const { children, content, ...rest } = tile;
+    const next: TilesetTileNode = { ...rest };
+
+    const uri = content?.uri;
+    if (uri !== undefined) {
+      const identity = resolveTileIdentity(tile, uri);
+      if (identity !== null && shouldKeep(identity, keep)) {
+        shouldKeepTile = true;
+        next.content = { ...content, uri: new URL(uri, baseUrl).href };
+      }
+      // Otherwise the content is dropped so Cesium does not load it.
+    } else if (content !== undefined) {
+      next.content = { ...content };
+    }
+
+    if (children !== undefined && children.length > 0) {
+      const keptChildren = children
+        .map(prune)
+        .filter((child): child is TilesetTileNode => child !== null);
+      if (keptChildren.length > 0) {
+        next.children = keptChildren;
+        shouldKeepTile = true;
+      }
+    }
+
+    return shouldKeepTile ? next : null;
+  };
+
+  const newRoot = prune(source.root);
+  if (newRoot === null) {
+    throw new Error('None of the selected slices were found in the tileset.');
+  }
+  tightenBoundingVolumes(newRoot);
+
+  const { root: _root, ...restOfDocument } = source;
+  return { ...restOfDocument, root: newRoot };
+};
+
+/**
+ * After pruning, parent nodes still carry the full-cube bounding volume.
+ * Recompute region bounds from kept children so Cesium zoom/culling match
+ * the visible slices. Leave geometricError alone — collapsing it to the leaf
+ * value (0) stops Cesium from refining and loading content.
+ */
+const tightenBoundingVolumes = (tile: TilesetTileNode): void => {
+  if (tile.children !== undefined && tile.children.length > 0) {
+    for (const child of tile.children) {
+      tightenBoundingVolumes(child);
+    }
+    const childRegions = tile.children.map((child) => getRegion(child));
+    // Only tighten when every kept child exposes a region. Unioning a subset
+    // would produce a volume that culls the children we cannot account for
+    // (e.g. box/sphere bounding volumes).
+    if (
+      childRegions.length > 0 &&
+      childRegions.every((region): region is number[] => region !== null)
+    ) {
+      tile.boundingVolume = {
+        region: childRegions.reduce((acc, region) => unionRegions(acc, region)),
+      };
+    }
+  }
+};
+
+const getRegion = (tile: TilesetTileNode): number[] | null => {
+  const volume = tile.boundingVolume as { region?: number[] } | undefined;
+  const region = volume?.region;
+  if (
+    region === undefined ||
+    !Array.isArray(region) ||
+    region.length < 6 ||
+    region.some((value) => typeof value !== 'number')
+  ) {
+    return null;
+  }
+  return region;
+};
+
+const unionRegions = (a: number[], b: number[]): number[] => [
+  Math.min(a[0], b[0]),
+  Math.min(a[1], b[1]),
+  Math.max(a[2], b[2]),
+  Math.max(a[3], b[3]),
+  Math.min(a[4], b[4]),
+  Math.max(a[5], b[5]),
+];
+
+const resolveTileIdentity = (
+  tile: TilesetTileNode,
+  uri: string,
+): { direction: OgcSliceDirection | null; number: number } | null => {
+  const fromMeta = readTileSliceKey(tile);
+  if (fromMeta !== null) {
+    return fromMeta;
+  }
+  const fromUri = parseSliceFromUri(uri);
+  if (fromUri === null) {
+    return null;
+  }
+  return { direction: null, number: fromUri };
+};
+
+const shouldKeep = (
+  identity: { direction: OgcSliceDirection | null; number: number },
+  keep: SliceKeepSelector,
+): boolean => {
+  if (!keep.numbers.has(identity.number)) {
+    return false;
+  }
+  if (keep.direction === undefined) {
+    return true;
+  }
+  // URI-only identity has no direction — allow if number matches when pruning
+  // a single-axis tileset built from partitioned URI numbers.
+  if (identity.direction === null) {
+    return true;
+  }
+  return identity.direction === keep.direction;
+};
+
+export const toBlobUrl = (json: unknown): string => {
+  const blob = new Blob([JSON.stringify(json)], { type: 'application/json' });
+  return URL.createObjectURL(blob);
+};
+
+/**
+ * Wrap a blob tileset URL in a Cesium Resource that carries the original OGC
+ * auth headers so absolute child content URLs still authenticate.
+ */
+export const createAuthenticatedBlobResource = (
+  blobUrl: string,
+  headers: Record<string, string>,
+): Resource =>
+  new Resource({
+    url: blobUrl,
+    headers: { ...headers },
+  });
+
+export const extractResourceHeaders = (
+  resource: Resource,
+): Record<string, string> => {
+  const headers = resource.headers;
+  if (headers === undefined || headers === null) {
+    return {};
+  }
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof value === 'string') {
+      result[key] = value;
+    }
+  }
+  return result;
+};

--- a/ui/src/features/layer/slice/tileset-slice-prune.ts
+++ b/ui/src/features/layer/slice/tileset-slice-prune.ts
@@ -1,9 +1,6 @@
 import { Resource } from 'cesium';
 import { OgcSliceDirection } from 'src/features/layer/slice/tiles3d-slice.types';
-import {
-  parseSliceFromUri,
-  readTileSliceKey,
-} from 'src/features/layer/slice/tileset-slice-metadata';
+import { resolveSliceIdentity } from 'src/features/layer/slice/tileset-slice-metadata';
 
 interface TilesetTileNode {
   content?: { uri?: string };
@@ -55,7 +52,7 @@ export const pruneTilesetToSlices = (
 
     const uri = content?.uri;
     if (uri !== undefined) {
-      const identity = resolveTileIdentity(tile, uri);
+      const identity = resolveSliceIdentity(tile, uri);
       if (identity !== null && shouldKeep(identity, keep)) {
         shouldKeepTile = true;
         next.content = { ...content, uri: new URL(uri, baseUrl).href };
@@ -95,25 +92,33 @@ export const pruneTilesetToSlices = (
  * value (0) stops Cesium from refining and loading content.
  */
 const tightenBoundingVolumes = (tile: TilesetTileNode): void => {
-  if (tile.children !== undefined && tile.children.length > 0) {
-    for (const child of tile.children) {
-      tightenBoundingVolumes(child);
-    }
-    const childRegions = tile.children.map((child) => getRegion(child));
-    // Only tighten when every kept child exposes a region. Unioning a subset
-    // would produce a volume that culls the children we cannot account for
-    // (e.g. box/sphere bounding volumes).
-    if (
-      childRegions.length > 0 &&
-      childRegions.every((region): region is number[] => region !== null)
-    ) {
-      tile.boundingVolume = {
-        region: childRegions.reduce(
-          (acc, region) => unionRegions(acc, region),
-          childRegions[0],
-        ),
-      };
-    }
+  if (tile.children === undefined || tile.children.length === 0) {
+    return;
+  }
+  for (const child of tile.children) {
+    tightenBoundingVolumes(child);
+  }
+  if (tile.content !== undefined) {
+    // This tile keeps its own content in addition to its children (valid
+    // under ADD refinement). Its original bounding volume was already sized
+    // to cover that content, not just the children — recomputing it as a
+    // children-only union could shrink it and cull the tile's own geometry.
+    return;
+  }
+  const childRegions = tile.children.map((child) => getRegion(child));
+  // Only tighten when every kept child exposes a region. Unioning a subset
+  // would produce a volume that culls the children we cannot account for
+  // (e.g. box/sphere bounding volumes).
+  if (
+    childRegions.length > 0 &&
+    childRegions.every((region): region is number[] => region !== null)
+  ) {
+    tile.boundingVolume = {
+      region: childRegions.reduce(
+        (acc, region) => unionRegions(acc, region),
+        childRegions[0],
+      ),
+    };
   }
 };
 
@@ -139,21 +144,6 @@ const unionRegions = (a: number[], b: number[]): number[] => [
   Math.min(a[4], b[4]),
   Math.max(a[5], b[5]),
 ];
-
-const resolveTileIdentity = (
-  tile: TilesetTileNode,
-  uri: string,
-): { direction: OgcSliceDirection | null; number: number } | null => {
-  const fromMeta = readTileSliceKey(tile);
-  if (fromMeta !== null) {
-    return fromMeta;
-  }
-  const fromUri = parseSliceFromUri(uri);
-  if (fromUri === null) {
-    return null;
-  }
-  return { direction: null, number: fromUri };
-};
 
 const shouldKeep = (
   identity: { direction: OgcSliceDirection | null; number: number },

--- a/ui/src/features/layer/slice/tileset-slice-prune.ts
+++ b/ui/src/features/layer/slice/tileset-slice-prune.ts
@@ -176,6 +176,41 @@ export const toBlobUrl = (json: unknown): string => {
 };
 
 /**
+ * Rewrite every content URI in the tileset to an absolute URL so that a
+ * blob-based root still resolves children against the OGC/S3 base.
+ */
+export const absolutizeTilesetUris = (
+  original: unknown,
+  baseUrl: string,
+): unknown => {
+  if (original === null || typeof original !== 'object') {
+    return original;
+  }
+  const source = original as TilesetJson;
+  if (source.root === undefined) {
+    return original;
+  }
+
+  const rewrite = (tile: TilesetTileNode): TilesetTileNode => {
+    const { children, content, ...rest } = tile;
+    const next: TilesetTileNode = { ...rest };
+    if (content !== undefined) {
+      const { uri, ...restContent } = content;
+      next.content =
+        uri !== undefined && uri !== ''
+          ? { ...restContent, uri: new URL(uri, baseUrl).href }
+          : { ...restContent };
+    }
+    if (children !== undefined && children.length > 0) {
+      next.children = children.map(rewrite);
+    }
+    return next;
+  };
+
+  return { ...source, root: rewrite(source.root) };
+};
+
+/**
  * Wrap a blob tileset URL in a Cesium Resource that carries the original OGC
  * auth headers so absolute child content URLs still authenticate.
  */

--- a/ui/src/features/layout/sidebar/layout-sidebar.element.ts
+++ b/ui/src/features/layout/sidebar/layout-sidebar.element.ts
@@ -80,10 +80,6 @@ export class LayoutSidebar extends CoreElement {
     }
   };
 
-  private readonly handleLexicToggle = () => {
-    this.filterService.toggle();
-  };
-
   private ensureLexicModuleLoaded(): void {
     if (customElements.get('ngm-lexic-filter-panel') === undefined) {
       void import('src/features/lexic/lexic.module');
@@ -136,9 +132,11 @@ export class LayoutSidebar extends CoreElement {
       </ngm-navigation-panel-header>
       ${this.renderPanel()}
     </ngm-navigation-panel>
-    ${this.isLexicOpen
-      ? html`<ngm-lexic-filter-panel></ngm-lexic-filter-panel>`
-      : ''}
+    ${
+      this.isLexicOpen
+        ? html`<ngm-lexic-filter-panel></ngm-lexic-filter-panel>`
+        : ''
+    }
   `;
 
   private readonly renderItems = () => html`

--- a/ui/src/services/ion.service.ts
+++ b/ui/src/services/ion.service.ts
@@ -102,6 +102,7 @@ export class IonService extends BaseService {
           infoBox: null,
           orderOfProperties: [],
           isPartiallyTransparent: false,
+          sliceSelection: null,
           customProperties: {},
         } satisfies Tiles3dLayer;
       default:

--- a/ui/src/services/pick.service.ts
+++ b/ui/src/services/pick.service.ts
@@ -114,7 +114,17 @@ export class PickService extends BaseService {
       return null;
     }
     if (viewer.scene.globe.show) {
-      return viewer.scene.globe.pick(ray, viewer.scene) ?? null;
+      const globePick = viewer.scene.globe.pick(ray, viewer.scene);
+      if (globePick !== undefined) {
+        return globePick;
+      }
+      // `Globe.pick` only intersects the terrain surface itself. When the
+      // camera is underground and looking away from the terrain (e.g. at
+      // underground content behind/below it), the ray never hits terrain and
+      // this returns `undefined` — fall through to the ellipsoid intersection
+      // below instead of aborting the whole pick, so callers (e.g. the info
+      // box's drill-picker) still get a position to work with and can find
+      // underground features via their own, more precise picking.
     }
 
     const interval = IntersectionTests.rayEllipsoid(ray, Ellipsoid.WGS84);

--- a/ui/src/services/pick.service.ts
+++ b/ui/src/services/pick.service.ts
@@ -114,17 +114,7 @@ export class PickService extends BaseService {
       return null;
     }
     if (viewer.scene.globe.show) {
-      const globePick = viewer.scene.globe.pick(ray, viewer.scene);
-      if (globePick !== undefined) {
-        return globePick;
-      }
-      // `Globe.pick` only intersects the terrain surface itself. When the
-      // camera is underground and looking away from the terrain (e.g. at
-      // underground content behind/below it), the ray never hits terrain and
-      // this returns `undefined` — fall through to the ellipsoid intersection
-      // below instead of aborting the whole pick, so callers (e.g. the info
-      // box's drill-picker) still get a position to work with and can find
-      // underground features via their own, more precise picking.
+      return viewer.scene.globe.pick(ray, viewer.scene) ?? null;
     }
 
     const interval = IntersectionTests.rayEllipsoid(ray, Ellipsoid.WGS84);

--- a/ui/src/slicer/Slicer.ts
+++ b/ui/src/slicer/Slicer.ts
@@ -129,7 +129,9 @@ export default class Slicer {
             // Imageries don't support clipping.
             return;
           case LayerType.Tiles3d:
-            this.applyClippingPlanesToTileset(controller.tileset);
+            for (const ts of controller.tilesets) {
+              this.applyClippingPlanesToTileset(ts);
+            }
             break;
           case LayerType.Voxel:
             this.applyClippingPlanesToTileset(controller.primitive);


### PR DESCRIPTION
Shows seismic layers as three interactive image-slice planes

Adds a "slice" mode for 3D-tiles seismic layers: instead of the full tileset, the layer renders as three orthogonal planes (inline, crossline, depth), each showing one image slice selected via HUD sliders. Slices are preloaded/cached in the background so switching between them is instant.

UI:
- New catalog detail panel with per-axis sliders (catalog-display-slice-detail.element.ts) to pick a slice per plane; multi-slice mode is present but disabled with a "coming soon" label.
- Sliders are keyboard-controllable (arrow/Home/End/PageUp/PageDown).
- Preload progress banner: subtle/low-key styling, hidden if slices were already cached, shown while loading, lingers briefly after completion.
- `sliceSelection` added to the Tiles3dLayer model, wired through catalog, Ion, and layer API mapping.
- Fixed a "zoom to object" button regression where it could get stuck disabled for slice layers.

Slice loading & caching (features/layer/slice/):
- Resolve and cache per-slice tileset JSON/metadata, tolerating the OGC gateway's redirect-to-S3 behaviour and occasional outages (falls back to a known public S3 URL for a real, deployed seismic layer).
- Double-buffered tileset swapping per axis with generation-counter based cancellation and in-flight de-duplication, so rapid slider changes never race or reuse a tileset mid-destroy.
- Background HTTP-cache warming and GPU tileset pre-building around the current selection, gated to only run while the HUD panel is open (pausing preserves already-fetched progress; only full layer teardown discards it), so reopening the panel doesn't needlessly reload slices.
- Disabled the tileset's environment-map bake per slice tileset to avoid transient WebGL errors from it being interrupted by fast tileset destruction while slices are swapped.
- LRU pruning of built tilesets to bound memory/GPU usage.

Picking & reliability fixes:
- pick.service.ts: fall back to an ellipsoid intersection when the primary terrain ray-cast misses (e.g. camera underground looking away from terrain) instead of aborting the pick — lets underground content (slice planes) be clicked reliably instead of only when the ray happens to hit terrain.
- layer-info-picker-for-wmts.ts: skip the slow, network-bound geo.admin identify request while the camera is underground.
- layer-info-picker-for-wmts.service.ts: 6s timeout on all geo.admin fetches, so a hanging/slow request can no longer stall the info box indefinitely.
- layer.controller.ts: the per-layer update queue now propagates/rejects on error instead of silently stalling.
- layer.service.ts: fixed a cold-start race where a fast session init could call loadLayers() before the layer API client was injected.