### PR TITLE
feat: implement patch to disable legacy camera controller in Cesium.

### DIFF
--- a/ui/src/features/controls/camera-controller.service.ts
+++ b/ui/src/features/controls/camera-controller.service.ts
@@ -16,6 +16,7 @@ import {
 } from 'cesium';
 import { firstValueFrom } from 'rxjs';
 import { patchTiltNadirGimbalLock } from 'src/features/controls/patch-tilt-nadir-gimbal-lock';
+import { patchLegacyCameraController } from 'src/features/controls/patch-legacy-camera-controller';
 import { isKnownScenePickingError } from 'src/services/pick.service';
 
 /**
@@ -101,10 +102,13 @@ export class CameraControllerService extends BaseService {
   private initialize(viewer: Viewer): void {
     this.viewer = viewer;
 
-    // Disable the old monolithic controller
+    // Disable the old monolithic controller.
+    //
+    // This *locks* `enableInputs` to `false` rather than merely assigning it,
+    // because Cesium force-restores the flag to `true` after every camera flight
+    // TODO: A cesium PR is on its way. remove the patch as soon as it is merged
     const scene = viewer.scene;
-    scene.screenSpaceCameraController.enableInputs = false;
-    scene.screenSpaceCameraController.enableCollisionDetection = false;
+    patchLegacyCameraController(scene);
 
     // Add the new modular controllers
     this.addController(this.panController);

--- a/ui/src/features/controls/patch-legacy-camera-controller.ts
+++ b/ui/src/features/controls/patch-legacy-camera-controller.ts
@@ -1,0 +1,58 @@
+import { Scene } from 'cesium';
+
+/**
+ * Permanently disables the legacy monolithic `ScreenSpaceCameraController`.
+ *
+ * We drive the camera with the modular controllers instead
+ * (`ScreenSpaceMapCameraController`, `ScreenSpaceTiltOrbitCameraController`,
+ * `ScreenSpaceZoomCameraController`), so the legacy controller must never
+ * process input — otherwise both handle the same mouse gestures at once.
+ *
+ * Assigning `enableInputs = false` once is *not* enough. CesiumJS's
+ * `CameraFlightPath.createTween` — used by every `camera.flyTo()` and
+ * `flyToBoundingSphere()` — does:
+ *
+ * ```js
+ * const controller = scene.screenSpaceCameraController;
+ * controller.enableInputs = false;
+ * const complete = wrapCallback(controller, options.complete);
+ * ```
+ *
+ * where `wrapCallback` unconditionally runs `controller.enableInputs = true`
+ * once the flight completes or is cancelled. Cesium assumes it owns the flag
+ * and restores it to `true` rather than to its previous value, so a single
+ * flight silently resurrects the legacy controller. It then fights the modular
+ * controllers for the same input, most visibly breaking orbit-around-a-point
+ * (CTRL+Drag / middle-drag).
+ *
+ * This also fires when the camera is already at the flight destination:
+ * `createTween` then short-circuits to `emptyFlight(complete, cancel)`, whose
+ * `complete` runs on the very next frame. That is why even a no-op "fly home"
+ * click — with the camera already at the home view — is enough to break
+ * rotation.
+ *
+ * Resetting the flag from a `preUpdate`/`postRender` listener would not close
+ * the gap either, because `Scene#initializeFrame` runs `this._tweens.update()`
+ * (which fires the flight's `complete`) *before*
+ * `this._screenSpaceCameraController.update()` within the same frame. Locking
+ * the property is therefore the only reliable fix.
+ *
+ * See: https://github.com/swisstopo/swissgeol-viewer-suite/issues/2055
+ * TODO: Remove once CesiumJS stops force-restoring `enableInputs`.
+ */
+export function patchLegacyCameraController(scene: Scene): void {
+  const controller = scene.screenSpaceCameraController;
+
+  controller.enableCollisionDetection = false;
+  controller.enableInputs = false;
+
+  Object.defineProperty(controller, 'enableInputs', {
+    get: () => false,
+    set: () => {
+      // Intentionally ignored: Cesium re-enables this after every camera
+      // flight, which would reactivate the legacy controller.
+    },
+    configurable: true,
+    enumerable: true,
+  });
+}


### PR DESCRIPTION
There is a Bug in Cesium, which enables old legacy camera controller after each flyTo() call.
I will create a PR on cesium directly to fix this bug.
Until this is reviewed, merged and released in Cesium we have to go with this monkey patch (which disables old legacy controllers completely)

The patch solves: #2055 and #2050 
To be reverted when our PR on cesium repo is merged and released.