### PR TITLE
zoom is cursor-aware and speed depends on target distance 

### DIFF
--- a/docs/camera-zoom.md
+++ b/docs/camera-zoom.md
@@ -1,0 +1,409 @@
+# Camera zoom
+
+How scroll-wheel / trackpad zoom works in this viewer, and how it differs from
+stock CesiumJS.
+
+Related issue: [#2058](https://github.com/swisstopo/swissgeol-viewer-suite/issues/2058)
+("Dynamische Zoom Geschwindigkeit abhängig von der Distanz zum Ziel").
+
+- Implementation: `ui/src/features/controls/approach-limited-zoom.controller.ts`
+- Wiring: `ui/src/features/controls/camera-controller.service.ts`
+- Debug HUD: `ui/src/features/controls/control-zoom-debug.element.ts`
+
+All CesiumJS references below were verified against the checked-out engine
+source at commit `6228ed4` (2026-08-28), which matches the released
+`cesium@1.144`/`1.145` behaviour.
+
+---
+
+## 1. What stock CesiumJS does
+
+Since 1.144 the monolithic `ScreenSpaceCameraController` has been superseded by
+composable controllers. We use `ScreenSpaceZoomCameraController`, whose entire
+zoom decision is these few lines of
+`packages/engine/Source/Scene/Controllers/ScreenSpaceZoomCameraController.js`:
+
+```js
+// L336-341
+let direction = camera.direction;
+let distance =
+  Cartesian3.magnitude(camera.positionWC) - ellipsoid.maximumRadius;
+
+// L343-350 — pick the screen position to zoom at
+let windowPosition = this.isDragging
+  ? this._screenSpaceDragPosition
+  : this._screenSpaceScrollPosition;
+if (!this.useDragPosition) {
+  windowPosition = this._screenSpaceOrigin;
+  windowPosition.x = clientWidth / 2.0;
+  windowPosition.y = clientHeight / 2.0;
+}
+
+// L351-360 — ray-pick the zoom target
+const target = this.pickWorldPosition(scene, windowPosition, this._target);
+if (defined(target)) {
+  direction = normalize(subtract(target, camera.positionWC));
+  distance = Cartesian3.distance(target, camera.positionWC);
+}
+
+// L368-383 — the step
+const zoom = dz * distance * this.zoomDistanceRatio;
+this._zoomDampenedResults = CesiumMath.smoothDamp(0, zoom, this.zoomVelocity, dt, ...);
+camera.move(direction, this.zoomDistance);
+```
+
+The important part: **the step is already proportional to the ray-picked
+distance to the target**, which is exactly what the issue asks for. Zoom speed
+is not derived from vertical height above terrain. The problems are elsewhere.
+
+### 1.1 The step is unbounded
+
+`dz` is the wheel delta accumulated during the frame. A browser wheel notch is
+`deltaY = ±100`, which `ScreenSpaceEventHandler` turns into `amount = 100`, and
+`zoomSensitivity = 0.2` turns into `dz = 20`. With Cesium's default
+`zoomDistanceRatio = 0.4` a **single notch requests `20 × 0.4 = 8 × distance`** —
+eight times past the target. Nothing clamps `zoom` to `distance`; only the
+`smoothDamp` low-pass keeps that from being instantly fatal.
+
+Consequences:
+
+- Several notches inside one frame (fast flick, trackpad, or a dropped frame)
+  push the damped result beyond `distance`, and the camera ends up **behind**
+  the object — the empty screen reported in the issue.
+- Because `smoothDamp` carries an absolute (m/s) velocity across frames while
+  `distance` keeps shrinking, the _relative_ approach speed accelerates as you
+  get closer. That is the "gets faster the closer you get" sensation.
+
+`maximumZoomVelocity` looks like the remedy but is not: `update()` only clamps
+`dz / dt` into `_zoomInputVelocity` (L330-335), which is consumed **exclusively**
+by the inertia branch (L310-315, off by default). The raw, unclamped `dz` drives
+the actual movement.
+
+Measured with a numerical simulation of `update()` (60 FPS unless noted,
+`d₀ = 1000 m`, our `zoomDistanceRatio = 0.1`):
+
+| Input                             | Travel            | Result                   |
+| --------------------------------- | ----------------- | ------------------------ |
+| 1 notch                           | 7.3 % of distance | fine                     |
+| 3 notches over 3 frames           | 21.6 %            | fine                     |
+| 10 notches in **one** frame       | 72.6 %            | close call               |
+| 5 notches in one frame @ 20 FPS   | **105 %**         | flies through the target |
+| same, with Cesium's default `0.4` | **>130 %**        | flies far through        |
+
+### 1.2 Zoom-to-cursor does not work
+
+The constructor declares `usePointerPosition` (L67) but `update()` reads
+`this.useDragPosition` (L346), which is never assigned on this class. The public
+property is therefore a **no-op**, `!undefined` is always `true`, and the zoom
+always targets the **screen centre**.
+
+In a tilted 3D view the screen centre is usually far behind whatever the user is
+pointing at — often the horizon. `distance` is then huge, so a step of "7 % of
+distance" is enormous relative to the object under the cursor, and you shoot
+straight past it. This is the single largest contributor to the reported
+symptom.
+
+The bug is still present at upstream HEAD (`6228ed4`).
+
+Fixing that property alone would not be enough, because the pointer position it
+would read is itself never updated — see §1.2b.
+
+### 1.2b The tracked pointer position is silently overwritten
+
+`connectedCallback()` registers `_handleZoomPosition` — the callback that keeps
+`_screenSpaceScrollPosition` current — on `MOUSE_MOVE`, and then immediately
+calls `ScreenSpaceInputBindings.registerDragInputBindings()`, which registers its
+drag `change` callback on `MOUSE_MOVE` with the **same** modifier (`undefined`
+for our bindings):
+
+```js
+// ScreenSpaceZoomCameraController.js, connectedCallback()
+handler.setInputAction(
+  this._handleZoomPosition.bind(this),
+  ScreenSpaceEventType.MOUSE_MOVE,
+);
+this._dragInputState = ScreenSpaceInputBindings.registerDragInputBindings(
+  handler,
+  this.dragInputs,
+  {
+    start: this._handleStartDrag.bind(this),
+    change: this._handleDrag.bind(this),
+  },
+);
+
+// ScreenSpaceInputBindings.js, registerDragInputBindings()
+handler.setInputAction(
+  changeCallback,
+  ScreenSpaceEventType.MOUSE_MOVE,
+  modifier,
+);
+```
+
+A `ScreenSpaceEventHandler` stores exactly one action per (type, modifier) pair,
+so the second registration **replaces** the first. `_screenSpaceScrollPosition`
+therefore never leaves its initial `(0, 0)`.
+
+This is why we track the pointer with our own `ScreenSpaceEventHandler`: a
+separate instance owns its own action table and cannot be clobbered. The drag
+anchor (`_screenSpaceDragPosition`, written from the button-down event) is not
+affected by the clash, so it is read from CesiumJS directly — that keeps the
+`dragInputs` bindings and their keyboard modifiers in CesiumJS's hands.
+
+### 1.3 The fallback distance is wrong outside the equator
+
+When `pickWorldPosition` returns `undefined` (cursor on the sky, or looking up
+from underground), `distance` keeps its seed value from L340:
+
+```js
+Cartesian3.magnitude(camera.positionWC) - ellipsoid.maximumRadius;
+```
+
+`maximumRadius` is the **equatorial** radius (6 378 137 m), but the geocentric
+radius at Swiss latitudes is only ≈6 365 000 m. Evaluated for lat 46.8°:
+
+| Camera height | Cesium's `distance` | Error                      |
+| ------------- | ------------------- | -------------------------- |
+| 2 000 m       | **−9 319 m**        | wrong sign, 4.7× too large |
+| 20 000 m      | 8 681 m             | 2.3× too small             |
+| 300 000 m     | 288 679 m           | ~4 % too small             |
+
+A negative `distance` flips `zoom`, so the camera bolts backwards. This branch is
+reachable in normal use here because the viewer is frequently tilted towards the
+horizon or looking up from below the surface.
+
+### 1.4 The glide plays back a speed that is already out of date
+
+`zoom = dz * distance * zoomDistanceRatio` (L368) is only evaluated on frames
+that carry input. That absolute metre value goes into `smoothDamp`, which plays
+it out over `zoomAnimationDuration` (0.45 s). On every following frame `dz` is
+`0`, so `distance` **drops out of the equation entirely** — the residual
+velocity is a speed in m/s derived from however far away the target was at the
+moment the wheel was turned.
+
+Flick the wheel hard from 100 km up and the controller banks a velocity suited
+to a target 100 km away, then keeps that speed while the last few hundred metres
+close. The glide has no idea the terrain came rushing up in the meantime.
+
+A per-frame cap does not really fix this. It fights the stale velocity on every
+single frame without ever discharging it, so the camera simply pins to the cap
+for the whole glide — the maximum permitted approach rate, sustained, which is
+what "racing through the terrain" feels like. It also stops protecting anything
+as soon as the distance changes for a reason other than our own movement:
+
+- the pointer ray drops past a ridge and lands on a valley far behind it,
+- terrain LOD refines and the surface moves up towards the camera,
+- the depth pick fails transiently while tiles stream in.
+
+The fix is to make the residual speed **proportional to the distance** rather
+than absolute, by rescaling the banked velocity by the fraction of the distance
+that is left after each frame. The glide then becomes a true exponential
+approach that decelerates by itself, whatever made the distance shrink.
+
+### 1.5 The depth buffer is empty while the globe is translucent
+
+This one is not a CesiumJS defect but a trap for anyone picking with
+`Scene.pickPosition`, and it bit us here.
+
+The viewer enables `scene.globe.translucency` whenever the background map's
+opacity is below 100 % or a transparent variant is selected
+(`LayerBackgroundController`). A translucent globe is drawn in the translucent
+pass and does **not** write to the depth buffer, so `Scene.pickPosition` returns
+`undefined` over plain terrain — silently, without throwing.
+
+Our pick chain then dropped through to `Camera.pickEllipsoid`, which returns a
+point on the WGS84 **ellipsoid** rather than on the ground. In Switzerland that
+is 400–4 500 m below the visible surface. Since the whole throttle is derived
+from the distance to the target, the measured distance became far larger than
+the real distance to the terrain, `maximumApproachFraction × distance` stopped
+constraining anything near the surface, and the camera punched straight through
+the terrain again — but only when the base map was not fully opaque, which is
+what made it look intermittent.
+
+The fix is to insert a math-based ray cast against the terrain
+(`Globe.pick`, via `pickPositionWithRay` in `cesiumutils.ts`) between the depth
+pick and the ellipsoid pick. It is independent of the depth buffer, so it
+returns the actual surface whatever the globe's opacity is. `cesiumutils`
+already used this fallback for scene picking; the camera controllers did not.
+
+### 1.6 What the old monolithic controller did better
+
+`ScreenSpaceCameraController.handleZoom()` had guards that were **not** carried
+over to the modular controllers
+(`packages/engine/Source/Scene/ScreenSpaceCameraController.js`):
+
+| Guard                                                                                                                            | Line |
+| -------------------------------------------------------------------------------------------------------------------------------- | ---- |
+| `rangeWindowRatio = Math.min(rangeWindowRatio, object.maximumMovementRatio)` — hard cap of 10 % of the window per frame          | 595  |
+| `if (distanceMeasure - distance < minHeight) distance = distanceMeasure - minHeight - 1.0` — the step can never reach the target | 612  |
+| `enableCollisionDetection` — terrain penetration blocked                                                                         | —    |
+
+Its per-notch step also came out far gentler: `CameraEventAggregator` converts a
+wheel notch to `arcLength = 7.5 * toRadians(delta)` (L179) ≈ 13 px, which with
+`zoomFactor = 5.0` (L145) yields **≈7.3 % of the distance per notch**.
+
+---
+
+## 2. What we do differently
+
+`ApproachLimitedZoomCameraController` is a plain **subclass** of
+`ScreenSpaceZoomCameraController`. It is not a patch: it overrides documented
+`Controller` lifecycle methods and the documented `pickWorldPosition` hook, and
+never reaches into a CesiumJS underscore-prefixed field.
+
+The one exception is `zoomVelocity`, used for the glide rescaling in §1.4. It is
+a real accessor on the class — CesiumJS's own `update()` both reads and writes it
+— but it is annotated `@private`, so it is missing from `Cesium.d.ts`. It is
+therefore read and written defensively: if a future release removes it, the
+rescaling silently stops and the step clamp alone remains in force.
+
+| #   | Stock CesiumJS                                                                                    | This viewer                                                                                                                                                                                                                                                          |
+| --- | ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Zoom target = **screen centre** (`usePointerPosition` is a no-op)                                 | Zoom target = **pointer position**, tracked with our own `ScreenSpaceEventHandler` and resolved inside `pickWorldPosition`. The broken property is never touched.                                                                                                    |
+| 2   | Target picked by `defaultPickWorldPosition` (ellipsoid / focus plane)                             | Target picked by `pickGeometryPosition` — the shared pick, so it hits **real geometry**: terrain, 3D Tiles, voxels, GeoTIFF surfaces. It tries the depth buffer, then a terrain ray cast (needed while the globe is translucent, §1.5), and only then the ellipsoid. |
+| 3   | Pick failure ⇒ `magnitude(positionWC) − maximumRadius` (see §1.3)                                 | Pick failure ⇒ synthetic target along the pointer ray at the camera's height above terrain. Cesium's broken branch is unreachable.                                                                                                                                   |
+| 4   | Step **unbounded** by the target distance                                                         | Step clamped to `maximumApproachFraction` (0.2) of the distance per frame. No burst or frame drop can punch through.                                                                                                                                                 |
+| 5   | Step decays to zero at the surface, so you only get underground by overshooting                   | Frames carrying **fresh zoom-in input** get at least `minimumApproachStep` (0.5 m), so descending below terrain stays possible — but controlled, and only while actively scrolling. The post-input glide never gets the floor, so a released wheel comes to rest.    |
+| 6   | `zoomDistanceRatio = 0.4` (≈29 % of distance per notch)                                           | `zoomDistanceRatio = 0.1` (≈7.3 % per notch), matching the legacy controller.                                                                                                                                                                                        |
+| 7   | Camera may land exactly on the target ⇒ `Cartesian3.normalize` throws `DeveloperError` next frame | A `targetSeparation` epsilon (0.1 mm) always keeps the camera off the singularity.                                                                                                                                                                                   |
+
+### Why not just configure it?
+
+Every public knob — `zoomDistanceRatio`, `zoomSensitivity`, `minimumZoomDistance`,
+`maximumZoomDistance`, `zoomAnimationDuration`, `maximumZoomVelocity`,
+`inertiaEnabled` — **scales** the step. None **bounds** it by the distance to the
+target, and none can reach the broken `useDragPosition` branch. A configuration-
+only fix is therefore not possible; subclassing is the smallest correct
+intervention.
+
+Note that `minimumZoomDistance` is actively unhelpful here: it is a _floor on the
+distance fed into the ratio_ (L362-366), so raising it makes the camera move
+**faster** near the target, not slower.
+
+### Order of operations per frame
+
+```
+update(scene, time)
+  ├─ zoom origin = zoom-drag anchor, else our tracked pointer
+  │    (screen centre until the pointer is first seen)
+  ├─ isZoomingIn = Cesium's own dz (_scrollDelta + _dragDelta.y) > 0
+  │    read before super.update() consumes it — fresh input vs. glide
+  ├─ remember camera position
+  ├─ super.update()                        ← Cesium moves the camera
+  │    └─ calls our pickWorldPosition       ← records target + targetSource
+  ├─ step = (newPosition − oldPosition) · directionToTarget
+  ├─ clamp: min(step, maxStep) → max(…, 0.5 m if isZoomingIn) → separation
+  │    maxStep = distance × min(1 − e^(−rate·dt), maximumApproachFraction)
+  ├─ camera.move(direction, clampedStep − step)   ← correction, same frame
+  └─ zoomVelocity ×= (distance − clampedStep) / distance   ← discharge the glide
+```
+
+The correction lands in the same frame: `ControllerHost.update()` runs from
+`Scene.render()` **before** the frame is drawn, so no intermediate position is
+ever visible.
+
+---
+
+## 3. Debug HUD
+
+Enable the HUD with the `zoomDebug` URL flag (e.g. `?zoomDebug`) to get
+`<control-zoom-debug>` in the lower-left corner. It samples at 10 Hz and shows:
+
+| Field                    | Meaning                                                                                                                                   |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| **Picked object**        | What sits under the zoom origin: 3D Tile feature (with name and tileset), entity, primitive class, `Terrain (globe)`, or `nothing (sky)`. |
+| **Depth buffer**         | Whether `Scene.pickPosition` resolved the target, and whether globe translucency is why it could not (§1.5).                              |
+| **Target source**        | `depth buffer / terrain ray` (normal), `ray fallback (nothing hit)` (§1.3 branch avoided), or `none`.                                     |
+| **Zoom origin (px)**     | Screen position the zoom is aimed at — verifies zoom-to-cursor.                                                                           |
+| **Distance to target**   | The value that drives the step.                                                                                                           |
+| **Height above terrain** | For contrast: what a naive elevation-based implementation would have used.                                                                |
+| **Requested step**       | How far CesiumJS moved the camera this frame.                                                                                             |
+| **Applied step**         | How far it was allowed to keep.                                                                                                           |
+| **Max step**             | `distance × min(1 − e^(−rate·dt), maximumApproachFraction)`.                                                                              |
+| **Applied / distance**   | The step as a percentage — should stay ≤20 %.                                                                                             |
+| **Limit**                | Highlighted in yellow when a limit engaged: `maximumApproachFraction`, `minimumApproachStep` or `targetSeparation`.                       |
+| **Input this frame**     | `zooming in` (fresh input) vs. `glide` (damped tail).                                                                                     |
+| **Frame time**           | The `dt` the approach rate was evaluated over — watch this spike while terrain tiles stream in.                                           |
+| **Banked velocity**      | CesiumJS's residual zoom speed before rescaling. This is the value that used to outlive the geometry it was computed for (§1.4).          |
+| **Velocity rescaled to** | The fraction the banked velocity was cut to this frame. Highlighted whenever the glide is being discharged.                               |
+
+The bottom block lists the live tuning values so they can be compared against
+the defaults documented above.
+
+### Reproducing the original bug
+
+1. Open the viewer with `?zoomDebug` and tilt the camera so the horizon is
+   visible.
+2. Point the cursor at a building or borehole in the lower half of the screen.
+3. Flick the wheel hard. Watch **Limit** turn yellow and **Applied / distance**
+   stay at 20 % instead of exceeding 100 %.
+4. Compare **Distance to target** (small, the object) with **Height above
+   terrain** — before the fix, the step was derived from the screen-centre
+   distance instead, which is typically orders of magnitude larger.
+
+---
+
+## 4. Upstream, and how to remove this override
+
+### Why this override exists at all
+
+We would much rather configure the stock controller than subclass it. We cannot,
+for two reasons.
+
+1. **The knobs that sound like they would fix this do nothing.**
+   `maximumZoomVelocity` never limits the zoom speed, and `maximumZoomDistance`
+   never bounds the camera — see [§Why not just configure it?](#why-not-just-configure-it).
+   There is no supported value of any public property that prevents the overshoot.
+2. **`usePointerPosition` is not honoured**, so zoom-to-cursor — the behaviour
+   the property is documented to provide — cannot be switched on at all (§1.2,
+   §1.2b).
+
+Both are defects in `cesium@1.144.0` rather than gaps in its feature set, so the
+override is a **temporary patch against upstream bugs**, not a product decision.
+It is deliberately built as a subclass that reuses CesiumJS's own damping,
+inertia and input handling, and only intervenes at the two points where the
+stock behaviour is wrong. That keeps the surface to delete small.
+
+This is the same arrangement as `patch-legacy-camera-controller.ts` and
+`patch-tilt-nadir-gimbal-lock.ts`: local, self-contained, and to be dropped once
+the fix ships upstream.
+
+### When it can be removed
+
+Delete the override once a CesiumJS release satisfies **all** of the following.
+Each is directly asserted by a test in `approach-limited-zoom.controller.test.ts`,
+so the checks are cheap to run against a new version.
+
+| #   | Condition                                                                                                                                                         | How to check                                                                                                                                                                |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | The zoom step is bounded by the distance to the target, so a large `dz` at a low frame rate cannot move the camera past — or through — the thing being zoomed at. | The control case `is not bounded by the stock controller, which does overshoot` in the test file must start **failing**. That test exists precisely as a tripwire for this. |
+| 2   | `usePointerPosition = true` actually zooms towards the cursor.                                                                                                    | Set it on a stock `ScreenSpaceZoomCameraController` and confirm `pickWorldPosition` receives the pointer position rather than the canvas centre.                            |
+| 3   | The no-target fallback distance is a real height above the surface and never goes negative outside the tropics.                                                   | Zoom in with the cursor on the sky over Switzerland; the camera must not move _away_ from the ground.                                                                       |
+| 4   | The damped glide re-evaluates its speed against the current distance instead of replaying the speed banked at input time (§1.4).                                  | Zoom hard towards a small object and release; the tail of the movement must not overshoot it.                                                                               |
+
+Conditions 1–3 are hard blockers. Condition 4 is a quality issue: without it the
+glide will still overshoot, so keep the `scaleZoomVelocity` rescaling even if 1–3 are
+fixed and the rest of the subclass goes.
+
+### How to remove it
+
+1. In `camera-controller.service.ts`, swap `ApproachLimitedZoomCameraController`
+   back for `ScreenSpaceZoomCameraController` and set `usePointerPosition = true`
+   alongside the existing `zoomDistanceRatio` and `pickWorldPosition`
+   assignments.
+2. Delete `approach-limited-zoom.controller.ts` and
+   `approach-limited-zoom.controller.test.ts`.
+3. Delete `control-zoom-debug.element.ts`, its import in `controls.module.ts`,
+   the `showZoomDebug` state and `when()` block in `ngm-app.ts`, and
+   `getZoomDebugParam()` in `permalink.ts`. The HUD only reports this
+   subclass's internals and has no meaning without it.
+4. Delete this document.
+
+**Keep** the changes to `pickWorldPositionWithDepthBuffer` and
+`pickPositionWithRay` (§1.5). They fix our own picking under a translucent
+globe, are independent of the zoom controller, and are used elsewhere.
+
+Then re-run the manual check in
+[§Reproducing the original bug](#reproducing-the-original-bug) with `?zoomDebug`
+removed: tilt the horizon into view, point at a small object low on the screen,
+and flick the wheel hard. If the camera still shoots past it, upstream is not
+fixed yet — restore the override.

--- a/ui/src/cesiumutils.ts
+++ b/ui/src/cesiumutils.ts
@@ -98,22 +98,36 @@ function tryPickScenePosition(
   }
 }
 
-function pickPositionWithRay(
+/**
+ * Math-based ray cast against the globe's terrain, falling back to the
+ * ellipsoid when the globe is hidden.
+ *
+ * Unlike `Scene.pickPosition` this does not depend on the depth buffer, so it
+ * keeps working while the globe is rendered translucently. It also returns the
+ * actual *terrain* surface, whereas `Camera.pickEllipsoid` returns the WGS84
+ * ellipsoid — up to several kilometres lower in the Alps.
+ */
+export function pickPositionWithRay(
   scene: Scene,
   windowPosition: Cartesian2,
+  result?: Cartesian3,
 ): Cartesian3 | undefined {
   const ray = scene.camera.getPickRay(windowPosition);
   if (ray === undefined) {
     return undefined;
   }
-  if (scene.globe.show) {
-    return scene.globe.pick(ray, scene) ?? undefined;
+  if (scene.globe?.show) {
+    const position = scene.globe.pick(ray, scene);
+    if (position === undefined) {
+      return undefined;
+    }
+    return result === undefined ? position : Cartesian3.clone(position, result);
   }
   const interval = IntersectionTests.rayEllipsoid(ray, Ellipsoid.WGS84);
   if (interval === undefined) {
     return undefined;
   }
-  return Ray.getPoint(ray, interval.start);
+  return Ray.getPoint(ray, interval.start, result);
 }
 
 /**

--- a/ui/src/features/controls/approach-limited-zoom.controller.test.ts
+++ b/ui/src/features/controls/approach-limited-zoom.controller.test.ts
@@ -1,0 +1,369 @@
+import { describe, expect, it } from 'vitest';
+import {
+  Cartesian2,
+  Cartesian3,
+  Ellipsoid,
+  JulianDate,
+  ScreenSpaceZoomCameraController,
+} from 'cesium';
+import { ApproachLimitedZoomCameraController } from './approach-limited-zoom.controller';
+
+const CLIENT_WIDTH = 1600;
+const CLIENT_HEIGHT = 900;
+
+/**
+ * Minimal stand-in for the parts of `Scene`/`Camera` that
+ * `ScreenSpaceZoomCameraController#update` touches.
+ */
+const createScene = (position: Cartesian3) => {
+  const camera = {
+    position: Cartesian3.clone(position),
+    direction: new Cartesian3(0, 0, -1),
+    get positionWC() {
+      return this.position;
+    },
+    move(direction: Cartesian3, amount: number) {
+      this.position = Cartesian3.add(
+        this.position,
+        Cartesian3.multiplyByScalar(direction, amount, new Cartesian3()),
+        new Cartesian3(),
+      );
+    },
+  };
+  return {
+    canvas: { clientWidth: CLIENT_WIDTH, clientHeight: CLIENT_HEIGHT },
+    camera,
+    ellipsoid: Ellipsoid.WGS84,
+  };
+};
+
+interface ControllerInternals {
+  _lastUpdateTime: number;
+  /** CesiumJS's own scroll accumulator, normally fed by its wheel handler. */
+  _scrollDelta: number;
+  /** CesiumJS's own drag accumulator, normally fed by its drag handler. */
+  _dragDelta: Cartesian2;
+  _dragInputState: { isDragging: boolean } | undefined;
+  _screenSpaceDragPosition: Cartesian2;
+  /** Our own frame clock, which must advance in step with CesiumJS's. */
+  lastFrameTime: number;
+}
+
+const createController = (target: Cartesian3) => {
+  const controller = new ApproachLimitedZoomCameraController();
+  controller.pickGeometryPosition = (_scene, _windowPosition, result) =>
+    Cartesian3.clone(target, result);
+  return controller;
+};
+
+/**
+ * Runs `frameCount` frames at a fixed `dt`. `scrollDelta` is fed on the first
+ * frame only, unless `isHeld` is set, in which case every frame receives it.
+ *
+ * The delta is written to CesiumJS's own `_scrollDelta`, exactly as its wheel
+ * handler does, so the controller reads it through the same path it does in the
+ * browser.
+ */
+const run = (
+  controller: ScreenSpaceZoomCameraController,
+  scene: ReturnType<typeof createScene>,
+  { scrollDelta = 0, frameCount = 1, dt = 1 / 60, isHeld = false } = {},
+) => {
+  const internals = controller as unknown as ControllerInternals;
+  for (let frame = 0; frame < frameCount; frame++) {
+    const delta = frame === 0 || isHeld ? scrollDelta : 0;
+    internals._lastUpdateTime = performance.now() - dt * 1000;
+    internals.lastFrameTime = performance.now() - dt * 1000;
+    internals._scrollDelta = delta;
+    controller.update(scene as never, JulianDate.now());
+  }
+};
+
+describe('ApproachLimitedZoomCameraController', () => {
+  const target = new Cartesian3(0, 0, 0);
+  const start = new Cartesian3(0, 0, 1000);
+
+  it('never travels more than the configured fraction of the distance in one frame', () => {
+    const scene = createScene(start);
+    const controller = createController(target);
+
+    // A violent scroll burst (10 wheel notches) combined with a 20 FPS frame.
+    run(controller, scene, { scrollDelta: 200, dt: 1 / 20 });
+
+    const distance = Cartesian3.distance(scene.camera.positionWC, target);
+    expect(distance).toBeGreaterThanOrEqual(
+      1000 * (1 - controller.maximumApproachFraction) - 1e-6,
+    );
+  });
+
+  it('never overshoots the target, even over a long burst', () => {
+    const scene = createScene(start);
+    const controller = createController(target);
+
+    run(controller, scene, { scrollDelta: 200, dt: 1 / 20, frameCount: 200 });
+
+    // Still on the near side of the target: z must not have flipped sign.
+    expect(scene.camera.positionWC.z).toBeGreaterThan(0);
+  });
+
+  it('is not bounded by the stock controller, which does overshoot', () => {
+    const scene = createScene(start);
+    const stock = new ScreenSpaceZoomCameraController();
+    stock.pickWorldPosition = (
+      _scene: unknown,
+      _windowPosition: Cartesian2,
+      result: Cartesian3,
+    ) => Cartesian3.clone(target, result);
+
+    run(stock, scene, { scrollDelta: 200, dt: 1 / 20 });
+
+    expect(scene.camera.positionWC.z).toBeLessThan(0);
+  });
+
+  it('keeps a single wheel notch at a moderate, distance-proportional step', () => {
+    const scene = createScene(start);
+    const controller = createController(target);
+    controller.zoomDistanceRatio = 0.1;
+
+    run(controller, scene, { scrollDelta: 20, frameCount: 120 });
+
+    const travelled =
+      1000 - Cartesian3.distance(scene.camera.positionWC, target);
+    expect(travelled).toBeGreaterThan(0);
+    expect(travelled).toBeLessThan(1000 * 0.15);
+  });
+
+  it('does not clamp zooming away from the target', () => {
+    const scene = createScene(start);
+    const controller = createController(target);
+
+    run(controller, scene, { scrollDelta: -200, dt: 1 / 20 });
+
+    expect(scene.camera.positionWC.z).toBeGreaterThan(2000);
+  });
+
+  it('still allows descending through the target while the user keeps scrolling', () => {
+    const scene = createScene(new Cartesian3(0, 0, 2));
+    const controller = createController(target);
+
+    run(controller, scene, {
+      scrollDelta: 20,
+      dt: 1 / 60,
+      frameCount: 20,
+      isHeld: true,
+    });
+
+    expect(scene.camera.positionWC.z).toBeLessThan(0);
+  });
+
+  it('comes to rest instead of drifting through the target once input stops', () => {
+    const scene = createScene(new Cartesian3(0, 0, 2));
+    const controller = createController(target);
+
+    run(controller, scene, { scrollDelta: 20, dt: 1 / 60, frameCount: 300 });
+
+    expect(scene.camera.positionWC.z).toBeGreaterThan(0);
+  });
+
+  // The glide is where the danger sits: CesiumJS banks an absolute speed in m/s
+  // that was derived from the distance at input time and never revisits it.
+  describe('post-input glide', () => {
+    const highStart = new Cartesian3(0, 0, 100_000);
+
+    it('decays the banked velocity as the target draws nearer', () => {
+      const scene = createScene(highStart);
+      const controller = createController(target);
+
+      run(controller, scene, { scrollDelta: 400, dt: 1 / 60, frameCount: 3 });
+      const early = Math.abs(controller.debug.zoomVelocity);
+      const earlyDistance = Cartesian3.distance(
+        scene.camera.positionWC,
+        target,
+      );
+
+      run(controller, scene, { dt: 1 / 60, frameCount: 20 });
+      const late = Math.abs(controller.debug.zoomVelocity);
+      const lateDistance = Cartesian3.distance(scene.camera.positionWC, target);
+
+      expect(lateDistance).toBeLessThan(earlyDistance);
+      // The speed must have fallen at least as steeply as the distance did.
+      expect(late / early).toBeLessThanOrEqual(lateDistance / earlyDistance);
+    });
+
+    it('does not race through the target after a fast burst from high up', () => {
+      const scene = createScene(highStart);
+      const controller = createController(target);
+
+      // 20 wheel notches in a single frame, then pure glide.
+      run(controller, scene, { scrollDelta: 400, dt: 1 / 60, frameCount: 240 });
+
+      expect(scene.camera.positionWC.z).toBeGreaterThan(0);
+    });
+
+    it('closes a comparable distance whatever the frame rate is', () => {
+      const runFor = (dt: number, frameCount: number) => {
+        const scene = createScene(highStart);
+        const controller = createController(target);
+        run(controller, scene, { scrollDelta: 400, dt, frameCount });
+        return Cartesian3.distance(scene.camera.positionWC, target);
+      };
+
+      // One second of wall-clock time at 60 FPS versus a 10 FPS stall.
+      const smooth = runFor(1 / 60, 60);
+      const stuttering = runFor(1 / 10, 10);
+
+      expect(stuttering).toBeGreaterThan(smooth * 0.5);
+      expect(stuttering).toBeLessThan(smooth * 2);
+    });
+
+    it('reacts when the target suddenly turns out to be much nearer', () => {
+      const scene = createScene(highStart);
+      const controller = new ApproachLimitedZoomCameraController();
+      const currentTarget = { value: target };
+      controller.pickGeometryPosition = (_scene, _windowPosition, result) =>
+        Cartesian3.clone(currentTarget.value, result);
+
+      run(controller, scene, { scrollDelta: 400, dt: 1 / 60, frameCount: 5 });
+
+      // Terrain refines, or the pointer ray drops onto a near ridge: the
+      // surface is suddenly just ahead of a camera still carrying a speed
+      // banked for a target 100 km away.
+      const { z } = scene.camera.positionWC;
+      currentTarget.value = new Cartesian3(0, 0, z - 50);
+
+      run(controller, scene, { dt: 1 / 60, frameCount: 240 });
+
+      expect(scene.camera.positionWC.z).toBeGreaterThan(z - 50);
+    });
+  });
+
+  // The controller reads CesiumJS's own `dz` accumulators instead of mirroring
+  // the DOM events, so these assert that the fields are still wired up and that
+  // the sign really does mean what `minimumApproachStep` assumes it means.
+  describe('zoom input detection', () => {
+    it('reports fresh scroll input towards the target as zooming in', () => {
+      const scene = createScene(start);
+      const controller = createController(target);
+
+      run(controller, scene, { scrollDelta: 20 });
+
+      expect(controller.debug.isZoomingIn).toBe(true);
+      // The sign is only meaningful if the camera really moved towards the
+      // target on that same frame.
+      expect(scene.camera.positionWC.z).toBeLessThan(start.z);
+    });
+
+    it('reports scroll input away from the target as not zooming in', () => {
+      const scene = createScene(start);
+      const controller = createController(target);
+
+      run(controller, scene, { scrollDelta: -20 });
+
+      expect(controller.debug.isZoomingIn).toBe(false);
+      expect(scene.camera.positionWC.z).toBeGreaterThan(start.z);
+    });
+
+    it('accounts for drag input, not just the scroll wheel', () => {
+      const scene = createScene(start);
+      const controller = createController(target);
+      const internals = controller as unknown as ControllerInternals;
+
+      internals._lastUpdateTime = performance.now() - 1000 / 60;
+      internals.lastFrameTime = performance.now() - 1000 / 60;
+      internals._dragDelta.y = 20;
+      controller.update(scene as never, JulianDate.now());
+
+      expect(controller.debug.isZoomingIn).toBe(true);
+      expect(scene.camera.positionWC.z).toBeLessThan(start.z);
+    });
+
+    it('treats the post-input glide as not zooming in', () => {
+      const scene = createScene(start);
+      const controller = createController(target);
+
+      run(controller, scene, { scrollDelta: 20, frameCount: 2 });
+
+      expect(controller.debug.isZoomingIn).toBe(false);
+    });
+  });
+
+  // The zoom anchor. CesiumJS's own `_screenSpaceScrollPosition` cannot be used:
+  // its `MOUSE_MOVE` action is overwritten by the drag bindings registered right
+  // after it, so it never leaves (0, 0). These drive the pointer through the
+  // same callback the controller registers on its own handler.
+  describe('zoom origin', () => {
+    const capture = (
+      scene: ReturnType<typeof createScene>,
+      configure: (
+        controller: ApproachLimitedZoomCameraController,
+        internals: ControllerInternals,
+      ) => void = () => {},
+    ) => {
+      const controller = new ApproachLimitedZoomCameraController();
+      const seen = new Cartesian2();
+      controller.pickGeometryPosition = (_scene, windowPosition, result) => {
+        Cartesian2.clone(windowPosition, seen);
+        return Cartesian3.clone(target, result);
+      };
+      configure(controller, controller as unknown as ControllerInternals);
+      run(controller, scene, { scrollDelta: 20 });
+      return seen;
+    };
+
+    it('zooms at the screen centre until the pointer has moved', () => {
+      const seen = capture(createScene(start));
+
+      expect(seen.x).toBe(CLIENT_WIDTH / 2);
+      expect(seen.y).toBe(CLIENT_HEIGHT / 2);
+    });
+
+    it('zooms at the pointer once it has moved', () => {
+      const seen = capture(createScene(start), (controller) => {
+        controller.handlePointerMove({ endPosition: new Cartesian2(100, 200) });
+      });
+
+      expect(seen).toEqual(new Cartesian2(100, 200));
+    });
+
+    it('follows the pointer as it keeps moving', () => {
+      const seen = capture(createScene(start), (controller) => {
+        controller.handlePointerMove({ endPosition: new Cartesian2(100, 200) });
+        controller.handlePointerMove({ endPosition: new Cartesian2(640, 480) });
+      });
+
+      expect(seen).toEqual(new Cartesian2(640, 480));
+    });
+
+    it('does not alias the event position it was handed', () => {
+      const position = new Cartesian2(100, 200);
+      const seen = capture(createScene(start), (controller) => {
+        controller.handlePointerMove({ endPosition: position });
+        position.x = 999;
+      });
+
+      expect(seen).toEqual(new Cartesian2(100, 200));
+    });
+
+    it('keeps the anchor at the drag start while a zoom drag is in progress', () => {
+      const seen = capture(createScene(start), (controller, internals) => {
+        controller.handlePointerMove({ endPosition: new Cartesian2(100, 200) });
+        internals._screenSpaceDragPosition.x = 300;
+        internals._screenSpaceDragPosition.y = 400;
+        internals._dragInputState = { isDragging: true };
+      });
+
+      expect(seen).toEqual(new Cartesian2(300, 400));
+    });
+
+    it('returns to the pointer once the zoom drag ends', () => {
+      const seen = capture(createScene(start), (controller, internals) => {
+        controller.handlePointerMove({ endPosition: new Cartesian2(100, 200) });
+        internals._screenSpaceDragPosition.x = 300;
+        internals._screenSpaceDragPosition.y = 400;
+        internals._dragInputState = { isDragging: false };
+      });
+
+      expect(seen).toEqual(new Cartesian2(100, 200));
+    });
+  });
+});

--- a/ui/src/features/controls/approach-limited-zoom.controller.ts
+++ b/ui/src/features/controls/approach-limited-zoom.controller.ts
@@ -1,0 +1,611 @@
+import {
+  Cartesian2,
+  Cartesian3,
+  Cartographic,
+  JulianDate,
+  Ray,
+  Scene,
+  ScreenSpaceEventHandler,
+  ScreenSpaceEventType,
+  ScreenSpaceZoomCameraController,
+} from 'cesium';
+
+const scratchCameraPosition = new Cartesian3();
+const scratchToTarget = new Cartesian3();
+const scratchDirection = new Cartesian3();
+const scratchDisplacement = new Cartesian3();
+const scratchFallbackRay = new Ray();
+const scratchFallbackOffset = new Cartesian3();
+const scratchCartographic = new Cartographic();
+
+/** Smallest distance, in meters, kept between the camera and the zoom target. */
+const MINIMUM_TARGET_SEPARATION = 1e-4;
+
+/** Frame duration assumed before a second frame has been observed. */
+const DEFAULT_FRAME_SECONDS = 1 / 60;
+
+/**
+ * Shortest frame duration the approach rate is evaluated over, so that two
+ * updates within the same clock tick cannot collapse the allowance to zero.
+ */
+const MINIMUM_FRAME_SECONDS = 1 / 240;
+
+/**
+ * Longest frame duration the approach rate is evaluated over. Without this, a
+ * tab switch or a long tile-loading stall would produce a single frame that is
+ * allowed to close nearly the whole distance to the target.
+ */
+const MAXIMUM_FRAME_SECONDS = 0.1;
+
+export type PickWorldPosition = (
+  scene: Scene,
+  windowPosition: Cartesian2,
+  result: Cartesian3,
+) => Cartesian3 | undefined;
+
+/** How the zoom target for the current frame was obtained. */
+export type ZoomTargetSource =
+  /** Depth buffer or ellipsoid hit under the pointer. */
+  | 'geometry'
+  /** Nothing was hit; a point along the pointer ray was synthesised. */
+  | 'fallback'
+  /** No target at all — CesiumJS's own ellipsoid-height fallback applies. */
+  | 'none';
+
+/** Which limit, if any, altered CesiumJS's zoom step this frame. */
+export type ZoomClamp =
+  | 'none'
+  | 'maximumApproachRate'
+  | 'maximumApproachFraction'
+  | 'minimumApproachStep'
+  | 'targetSeparation';
+
+/**
+ * Per-frame snapshot of the zoom decision, for the debug HUD
+ * (`<control-zoom-debug>`). Mutated in place; never retain a reference to the
+ * nested vectors.
+ */
+export interface ZoomDebugState {
+  targetSource: ZoomTargetSource;
+  /** Screen position, in CSS pixels, the zoom is aimed at. */
+  readonly zoomOrigin: Cartesian2;
+  /** World position the zoom is aimed at, if any. */
+  readonly target: Cartesian3;
+  /** Distance from the camera to the target, in meters. */
+  distance: number;
+  /** Distance CesiumJS moved the camera towards the target this frame. */
+  requestedStep: number;
+  /** Distance actually kept after clamping. */
+  appliedStep: number;
+  /**
+   * Upper bound derived from `maximumApproachRate` and
+   * `maximumApproachFraction`.
+   */
+  maximumStep: number;
+  clamp: ZoomClamp;
+  /** True while the frame carries fresh zoom-in input rather than glide. */
+  isZoomingIn: boolean;
+  /** Duration of the frame the decision was made for, in seconds. */
+  frameSeconds: number;
+  /** CesiumJS's banked zoom velocity before rescaling, in meters per second. */
+  zoomVelocity: number;
+  /** Factor the banked zoom velocity was rescaled by. */
+  velocityScale: number;
+}
+
+export interface ApproachLimitedZoomOptions
+  extends ScreenSpaceZoomCameraController.ControllerOptions {
+  /**
+   * The largest fraction of the remaining distance to the zoom target that the
+   * camera may close per second.
+   *
+   * This is the primary speed limit. It is expressed per second rather than per
+   * frame so that the zoom feels identical at 60 FPS and during the frame-rate
+   * dips that fast descents cause while terrain tiles stream in.
+   */
+  readonly maximumApproachRate?: number;
+
+  /**
+   * Hard ceiling on the fraction of the remaining distance that may be closed
+   * within a single frame, whatever `maximumApproachRate` works out to.
+   */
+  readonly maximumApproachFraction?: number;
+
+  /**
+   * The smallest step, in meters, that a frame carrying actual zoom-in input is
+   * guaranteed to travel.
+   *
+   * CesiumJS's step is proportional to the distance to the target, so it decays
+   * to nothing at the surface and the camera can never descend below it. Since
+   * this viewer explicitly supports travelling underground, every frame with
+   * fresh input is granted at least this much progress. It is not applied to the
+   * post-input glide, so a released wheel still comes to rest.
+   */
+  readonly minimumApproachStep?: number;
+}
+
+/**
+ * A {@link ScreenSpaceZoomCameraController} that keeps the scroll-wheel zoom
+ * from flying through the terrain or the object being zoomed at.
+ *
+ * See https://github.com/swisstopo/swissgeol-viewer-suite/issues/2058.
+ *
+ * This is a plain subclass: it overrides the documented `Controller` lifecycle
+ * methods and the documented
+ * {@link ScreenSpaceZoomCameraController#pickWorldPosition} hook. It also reads
+ * — and, for the banked velocity, writes — a handful of CesiumJS fields that are
+ * annotated `@private` and therefore missing from `Cesium.d.ts`. Those accesses
+ * all go through the guarded accessors at the bottom of the class and degrade
+ * gracefully if a future release renames them; see the note on each one.
+ *
+ * ## Why this is needed
+ *
+ * CesiumJS's zoom step is already proportional to the ray-picked distance to the
+ * target (`zoom = dz * distance * zoomDistanceRatio`), but nothing bounds the
+ * result by that distance:
+ *
+ * - A browser wheel notch is `deltaY = ±100`, which becomes `dz = 20` after
+ *   `zoomSensitivity`, so a single notch *requests* `20 * zoomDistanceRatio`
+ *   times the distance — several times past the target. Only the `smoothDamp`
+ *   low-pass keeps that survivable.
+ * - Multiple notches within one frame (a fast flick, a trackpad, or simply a
+ *   dropped frame) push the damped result beyond `distance` and the camera ends
+ *   up behind the target — the "empty screen" reported in the issue.
+ * - `maximumZoomVelocity` cannot prevent this: `update()` clamps `dz / dt` into
+ *   an input velocity that only the (off by default) inertia path consumes,
+ *   while the raw, unclamped `dz` drives the actual movement.
+ *
+ * The legacy monolithic `ScreenSpaceCameraController` did guard against this
+ * (`handleZoom()` clamps the step to `distanceMeasure - minimumZoomDistance`),
+ * but that safeguard was not carried over to the modular controllers, and none
+ * of the public knobs (`zoomDistanceRatio`, `zoomSensitivity`,
+ * `minimumZoomDistance`, `maximumZoomDistance`, `zoomAnimationDuration`) can
+ * reinstate it — they all *scale* the step, none *bound* it. Hence
+ * {@link ApproachLimitedZoomOptions.maximumApproachFraction}, applied in
+ * {@link update} after CesiumJS has moved the camera.
+ *
+ * Unlike the legacy controller, the approach is only decelerated, never blocked:
+ * this viewer lets users travel below the terrain surface.
+ *
+ * ## The glide carries a stale speed
+ *
+ * Bounding the per-frame step is not enough on its own. CesiumJS evaluates
+ * `zoom = dz * distance * zoomDistanceRatio` **only on frames that carry input**
+ * and hands that absolute metre value to `smoothDamp`, which then plays it out
+ * over `zoomAnimationDuration`. During the glide `dz` is zero, so `distance`
+ * stops entering the equation entirely: the banked velocity is a speed in m/s
+ * derived from however far away the target was *when the wheel was turned*.
+ *
+ * Flick the wheel hard from high altitude and the controller banks a velocity
+ * suited to a target tens of kilometres away, then keeps it while the last few
+ * hundred metres close — the glide simply does not know that the terrain came
+ * rushing up in the meantime. A per-frame cap fights that every frame without
+ * ever resolving it, and it breaks down as soon as the distance changes for a
+ * reason other than our own movement (the pointer ray dropping past a ridge
+ * onto a far valley, or terrain LOD refining the surface upwards).
+ *
+ * {@link update} therefore rescales the banked velocity by the fraction of the
+ * distance that remains after each frame. That makes the residual speed
+ * proportional to the distance instead of absolute, turning the glide into a
+ * true exponential approach that decelerates on its own — whatever caused the
+ * distance to shrink.
+ *
+ * ## Zoom target selection
+ *
+ * CesiumJS 1.144/1.145 declare `usePointerPosition` but read an (unassigned)
+ * `useDragPosition` in `update()`, so the public property is a no-op and the
+ * built-in zoom always targets the *screen centre* — usually the far horizon in
+ * a tilted view, which makes every notch overshoot whatever the user is actually
+ * pointing at.
+ *
+ * Rather than assigning the internal property, this controller resolves the
+ * target from the pointer inside `pickWorldPosition`, which CesiumJS documents
+ * as the supported way to choose "the world position from which to zoom".
+ *
+ * The pointer position has to be tracked by this controller, because CesiumJS's
+ * own `_screenSpaceScrollPosition` is never updated: `connectedCallback()`
+ * registers `_handleZoomPosition` on `MOUSE_MOVE`, and then
+ * `ScreenSpaceInputBindings.registerDragInputBindings()` registers its drag
+ * `change` callback on `MOUSE_MOVE` with the *same* modifier. A
+ * `ScreenSpaceEventHandler` keeps only one action per (type, modifier) pair, so
+ * the second registration silently replaces the first and the field stays at its
+ * initial `(0, 0)`. That is the deeper reason `usePointerPosition` cannot work
+ * upstream. A separate handler is immune, since it owns its own action table.
+ *
+ * The drag anchor (`_screenSpaceDragPosition`, set from the button-down event)
+ * is unaffected by that clash and is used as-is, which keeps the `dragInputs`
+ * bindings and their keyboard modifiers in CesiumJS's hands.
+ *
+ * ---
+ *
+ * **This is a temporary patch against upstream defects in `cesium@1.144.0`, not
+ * a permanent customisation.** None of the above can be fixed by configuration:
+ * `maximumZoomVelocity` and `maximumZoomDistance` have no effect, and
+ * `usePointerPosition` is never read. Once a CesiumJS release bounds the zoom
+ * step, honours `usePointerPosition` and fixes the ellipsoid fallback, this
+ * whole class should be deleted in favour of plain configuration — see
+ * *"Upstream, and how to remove this override"* in `docs/camera-zoom.md` for the
+ * acceptance checks and the step-by-step removal. The test
+ * `is not bounded by the stock controller, which does overshoot` is the tripwire:
+ * when it starts failing, upstream has fixed the main defect.
+ */
+export class ApproachLimitedZoomCameraController extends ScreenSpaceZoomCameraController {
+  readonly maximumApproachRate: number;
+  readonly maximumApproachFraction: number;
+  readonly minimumApproachStep: number;
+
+  /**
+   * Resolves the world position under a screen position. Assign the same
+   * depth-buffer-aware pick used by the other camera controllers.
+   */
+  pickGeometryPosition: PickWorldPosition = (scene, windowPosition, result) =>
+    scene.camera.pickEllipsoid(windowPosition, scene.ellipsoid, result);
+
+  /** @see ZoomDebugState */
+  readonly debug: ZoomDebugState = {
+    targetSource: 'none',
+    zoomOrigin: new Cartesian2(),
+    target: new Cartesian3(),
+    distance: Number.NaN,
+    requestedStep: 0,
+    appliedStep: 0,
+    maximumStep: Number.NaN,
+    clamp: 'none',
+    isZoomingIn: false,
+    frameSeconds: DEFAULT_FRAME_SECONDS,
+    zoomVelocity: 0,
+    velocityScale: 1,
+  };
+
+  private readonly zoomOrigin = new Cartesian2();
+  private readonly pointerPosition = new Cartesian2();
+  private hasPointerPosition = false;
+  private handler: ScreenSpaceEventHandler | undefined;
+  private target: Cartesian3 | undefined;
+  private lastFrameTime: number | undefined;
+
+  constructor(options: ApproachLimitedZoomOptions = {}) {
+    super(options);
+
+    this.maximumApproachRate = options.maximumApproachRate ?? 3.0;
+    this.maximumApproachFraction = options.maximumApproachFraction ?? 0.2;
+    this.minimumApproachStep = options.minimumApproachStep ?? 0.5;
+
+    // The `windowPosition` handed in by CesiumJS is unusable (see the class
+    // doc), so the tracked pointer position is used instead.
+    this.pickWorldPosition = (
+      scene: Scene,
+      _windowPosition: Cartesian2,
+      result: Cartesian3,
+    ): Cartesian3 | undefined => {
+      const geometry = this.pickGeometryPosition(
+        scene,
+        this.zoomOrigin,
+        result,
+      );
+      if (geometry !== undefined) {
+        this.debug.targetSource = 'geometry';
+        this.target = geometry;
+        return geometry;
+      }
+
+      const fallback = pickFallbackPosition(scene, this.zoomOrigin, result);
+      this.debug.targetSource = fallback === undefined ? 'none' : 'fallback';
+      this.target = fallback;
+      return fallback;
+    };
+  }
+
+  /**
+   * Records the pointer position for {@link resolveZoomOrigin}.
+   *
+   * Registered as the `MOUSE_MOVE` action of this controller's own handler; a
+   * bound property so that it can be registered and unit-tested directly.
+   */
+  readonly handlePointerMove = (event: {
+    readonly endPosition: Cartesian2;
+  }): void => {
+    Cartesian2.clone(event.endPosition, this.pointerPosition);
+    this.hasPointerPosition = true;
+  };
+
+  connectedCallback(element: HTMLElement): void {
+    super.connectedCallback(element);
+
+    // Tolerate a repeated connect without an intervening disconnect, which
+    // would otherwise leak the previous handler.
+    this.destroyHandler();
+
+    const handler = new ScreenSpaceEventHandler(element as HTMLCanvasElement);
+    this.handler = handler;
+    handler.setInputAction(
+      this.handlePointerMove,
+      ScreenSpaceEventType.MOUSE_MOVE,
+    );
+  }
+
+  disconnectedCallback(element: HTMLElement): void {
+    this.destroyHandler();
+    this.hasPointerPosition = false;
+    super.disconnectedCallback(element);
+  }
+
+  firstUpdate(scene: Scene, time: JulianDate): void {
+    super.firstUpdate(scene, time);
+    this.lastFrameTime = undefined;
+  }
+
+  update(scene: Scene, time: JulianDate): void {
+    this.resolveZoomOrigin(scene);
+
+    // Must be read *before* `super.update()`, which consumes and clears it.
+    const isZoomingIn = this.pendingZoomInput > 0;
+
+    const now = performance.now();
+    const frameSeconds =
+      this.lastFrameTime === undefined
+        ? DEFAULT_FRAME_SECONDS
+        : Math.min(
+            Math.max((now - this.lastFrameTime) / 1000, MINIMUM_FRAME_SECONDS),
+            MAXIMUM_FRAME_SECONDS,
+          );
+    this.lastFrameTime = now;
+
+    const debug = this.debug;
+    debug.frameSeconds = frameSeconds;
+    debug.zoomVelocity = this.bankedZoomVelocity ?? 0;
+    debug.velocityScale = 1;
+    debug.isZoomingIn = isZoomingIn;
+    debug.targetSource = 'none';
+    debug.distance = Number.NaN;
+    debug.maximumStep = Number.NaN;
+    debug.requestedStep = 0;
+    debug.appliedStep = 0;
+    debug.clamp = 'none';
+    Cartesian2.clone(this.zoomOrigin, debug.zoomOrigin);
+
+    const { camera } = scene;
+    const positionBefore = Cartesian3.clone(
+      camera.positionWC,
+      scratchCameraPosition,
+    );
+
+    this.target = undefined;
+    super.update(scene, time);
+
+    const target = this.target;
+    if (target === undefined) {
+      return;
+    }
+    Cartesian3.clone(target, debug.target);
+
+    const toTarget = Cartesian3.subtract(
+      target,
+      positionBefore,
+      scratchToTarget,
+    );
+    const distance = Cartesian3.magnitude(toTarget);
+    debug.distance = distance;
+    if (distance <= 0) {
+      return;
+    }
+    const direction = Cartesian3.divideByScalar(
+      toTarget,
+      distance,
+      scratchDirection,
+    );
+
+    const displacement = Cartesian3.subtract(
+      camera.positionWC,
+      positionBefore,
+      scratchDisplacement,
+    );
+    const step = Cartesian3.dot(displacement, direction);
+    debug.requestedStep = step;
+    debug.appliedStep = step;
+
+    // The rate is the real speed limit and is evaluated over the frame's actual
+    // duration, so a 10 FPS stall cannot close as much ground as six 60 FPS
+    // frames would have. The fraction is a hard ceiling for pathological frames.
+    const rateFraction = 1 - Math.exp(-this.maximumApproachRate * frameSeconds);
+    const isRateBinding = rateFraction < this.maximumApproachFraction;
+    const maximumStep =
+      distance * Math.min(rateFraction, this.maximumApproachFraction);
+    debug.maximumStep = maximumStep;
+
+    // Only the approach is bounded; zooming away from the target is harmless.
+    if (step < 0) {
+      return;
+    }
+
+    let clampedStep = Math.min(step, maximumStep);
+    if (clampedStep < step) {
+      debug.clamp = isRateBinding
+        ? 'maximumApproachRate'
+        : 'maximumApproachFraction';
+    }
+    if (isZoomingIn && clampedStep < this.minimumApproachStep) {
+      clampedStep = this.minimumApproachStep;
+      debug.clamp = 'minimumApproachStep';
+    }
+
+    // Landing exactly on the target would leave CesiumJS with a zero-length
+    // zoom direction on the next frame, which `Cartesian3.normalize` rejects
+    // with a `DeveloperError`. Always keep a sliver of separation.
+    if (Math.abs(distance - clampedStep) < MINIMUM_TARGET_SEPARATION) {
+      clampedStep = distance + MINIMUM_TARGET_SEPARATION;
+      debug.clamp = 'targetSeparation';
+    }
+
+    debug.appliedStep = clampedStep;
+
+    if (clampedStep !== step) {
+      camera.move(direction, clampedStep - step);
+    }
+
+    // Re-anchor CesiumJS's banked velocity to the distance that is actually
+    // left, so the post-input glide decelerates as the target draws nearer
+    // instead of coasting on a speed computed for a target that was far away.
+    const remaining = Math.max(distance - clampedStep, 0);
+    const velocityScale = Math.min(remaining / distance, 1);
+    debug.velocityScale = velocityScale;
+    this.scaleZoomVelocity(velocityScale);
+  }
+
+  /**
+   * CesiumJS's damped zoom velocity, or `undefined` if the accessor is gone.
+   *
+   * `zoomVelocity` is a real accessor on `ScreenSpaceZoomCameraController` (its
+   * own `update()` both reads and writes it), but it is annotated `@private` and
+   * therefore absent from `Cesium.d.ts`. Everything here degrades to the plain
+   * step clamp if a future release drops it, so it is read and written
+   * defensively rather than through a blanket cast.
+   */
+  private get bankedZoomVelocity(): number | undefined {
+    const velocity = (this as unknown as { zoomVelocity?: unknown })
+      .zoomVelocity;
+    return typeof velocity === 'number' && Number.isFinite(velocity)
+      ? velocity
+      : undefined;
+  }
+
+  /**
+   * The zoom input CesiumJS will act on this frame — exactly the `dz` its
+   * `update()` computes as `_scrollDelta + _dragDelta.y`, before it consumes and
+   * clears both.
+   *
+   * Reading CesiumJS's own accumulators rather than mirroring the DOM events
+   * with a second `ScreenSpaceEventHandler` is deliberate: a mirror has to
+   * re-implement the wheel/drag sign convention, the `dragInputs` and
+   * `scrollInputs` bindings and their keyboard modifiers, and the `enabled`
+   * flag, and it silently desynchronises the moment any of those change.
+   *
+   * The sign needs no convention of its own: CesiumJS moves the camera by
+   * `dz * distance * zoomDistanceRatio` along a direction that points *at* the
+   * zoom target, so `dz > 0` is by construction a movement towards it.
+   * {@link ApproachLimitedZoomCameraController.test} asserts that invariant.
+   *
+   * Returns `0` if a future release renames the fields, which only disables the
+   * {@link ApproachLimitedZoomOptions.minimumApproachStep} boost.
+   */
+  private get pendingZoomInput(): number {
+    const { _scrollDelta: scrollDelta, _dragDelta: dragDelta } =
+      this as unknown as {
+        _scrollDelta?: unknown;
+        _dragDelta?: { y?: unknown };
+      };
+    const scroll = typeof scrollDelta === 'number' ? scrollDelta : 0;
+    const drag = typeof dragDelta?.y === 'number' ? dragDelta.y : 0;
+    return scroll + drag;
+  }
+
+  /**
+   * The anchor of an in-progress zoom drag, i.e. where the button went down.
+   *
+   * `_screenSpaceDragPosition` and `isDragging` are `@private` and thus absent
+   * from `Cesium.d.ts`. Unlike `_screenSpaceScrollPosition` they *are* kept up
+   * to date (see the class doc), and reading them leaves the `dragInputs`
+   * bindings and their keyboard modifiers in CesiumJS's hands.
+   *
+   * Returns `undefined` when no zoom drag is in progress, or if a future release
+   * renames the fields — in which case the live pointer position is used.
+   */
+  private get dragAnchorPosition(): Cartesian2 | undefined {
+    const { isDragging, _screenSpaceDragPosition: dragPosition } =
+      this as unknown as {
+        isDragging?: unknown;
+        _screenSpaceDragPosition?: unknown;
+      };
+    if (isDragging !== true) {
+      return undefined;
+    }
+    return dragPosition instanceof Cartesian2 ? dragPosition : undefined;
+  }
+
+  private scaleZoomVelocity(scale: number): void {
+    const velocity = this.bankedZoomVelocity;
+    if (velocity === undefined) {
+      return;
+    }
+    (this as unknown as { zoomVelocity: number }).zoomVelocity =
+      velocity * scale;
+  }
+
+  private destroyHandler(): void {
+    if (this.handler !== undefined && !this.handler.isDestroyed()) {
+      this.handler.destroy();
+    }
+    this.handler = undefined;
+  }
+
+  private resolveZoomOrigin(scene: Scene): void {
+    // While a zoom drag is in progress the anchor stays where the gesture
+    // started, matching the behaviour of the tilt and pan controllers.
+    const anchor = this.dragAnchorPosition;
+    if (anchor !== undefined) {
+      Cartesian2.clone(anchor, this.zoomOrigin);
+      return;
+    }
+
+    // Zoom from the screen centre until the pointer has been seen at least
+    // once, so that input arriving beforehand does not aim at the top-left
+    // corner.
+    if (!this.hasPointerPosition) {
+      const { clientWidth, clientHeight } = scene.canvas;
+      this.zoomOrigin.x = clientWidth / 2;
+      this.zoomOrigin.y = clientHeight / 2;
+      return;
+    }
+    Cartesian2.clone(this.pointerPosition, this.zoomOrigin);
+  }
+}
+
+/**
+ * Fallback for when nothing can be picked under the pointer, e.g. when the ray
+ * points at the sky or up from underground.
+ *
+ * CesiumJS's own fallback computes
+ * `magnitude(camera.positionWC) - ellipsoid.maximumRadius`. `maximumRadius` is
+ * the *equatorial* radius (6'378'137 m), while the geocentric radius at Swiss
+ * latitudes is only about 6'365'000 m, so at 2'000 m above Switzerland it yields
+ * **-9'319 m** instead of `+2'000 m` — wrong by a factor of ~4.6 and, worse,
+ * negative, which flips the zoom direction and makes the camera bolt backwards.
+ *
+ * Returning a target along the pointer ray at the camera's height above terrain
+ * keeps the zoom speed tied to a meaningful distance and avoids that branch
+ * entirely.
+ */
+function pickFallbackPosition(
+  scene: Scene,
+  windowPosition: Cartesian2,
+  result: Cartesian3,
+): Cartesian3 | undefined {
+  const { camera, globe } = scene;
+
+  const ray = camera.getPickRay(windowPosition, scratchFallbackRay);
+  if (ray === undefined) {
+    return undefined;
+  }
+
+  const cartographic = Cartographic.fromCartesian(
+    camera.positionWC,
+    scene.ellipsoid,
+    scratchCartographic,
+  );
+  if (cartographic === undefined) {
+    return undefined;
+  }
+
+  const terrainHeight = globe?.getHeight(cartographic) ?? 0;
+  const distance = Math.abs(cartographic.height - terrainHeight);
+  if (distance <= 0) {
+    return undefined;
+  }
+
+  const offset = Cartesian3.multiplyByScalar(
+    ray.direction,
+    distance,
+    scratchFallbackOffset,
+  );
+  return Cartesian3.add(ray.origin, offset, result);
+}

--- a/ui/src/features/controls/camera-controller.service.test.ts
+++ b/ui/src/features/controls/camera-controller.service.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Cartesian2, Cartesian3, Ray, Scene } from 'cesium';
+import { pickWorldPositionWithDepthBuffer } from 'src/features/controls/camera-controller.service';
+
+const TERRAIN = new Cartesian3(1, 2, 3);
+const ELLIPSOID = new Cartesian3(9, 9, 9);
+const GEOMETRY = new Cartesian3(4, 5, 6);
+
+interface SceneOptions {
+  readonly depthPick?: Cartesian3 | undefined;
+  readonly globePick?: Cartesian3 | undefined;
+  readonly isGlobeShown?: boolean;
+}
+
+const createScene = ({
+  depthPick,
+  globePick,
+  isGlobeShown = true,
+}: SceneOptions) => {
+  const pickEllipsoid = vi.fn(
+    (_position: Cartesian2, _ellipsoid: unknown, result: Cartesian3) =>
+      Cartesian3.clone(ELLIPSOID, result),
+  );
+  const globeRayPick = vi.fn(() => globePick);
+  const scene = {
+    ellipsoid: {},
+    globe: {
+      show: isGlobeShown,
+      pick: globeRayPick,
+    },
+    camera: {
+      pickEllipsoid,
+      // Points away from the ellipsoid, so the math-based fallback misses it.
+      getPickRay: () =>
+        new Ray(new Cartesian3(1e8, 0, 0), Cartesian3.clone(Cartesian3.UNIT_X)),
+    },
+    pickPosition: vi.fn((_position: Cartesian2, result: Cartesian3) =>
+      depthPick === undefined ? undefined : Cartesian3.clone(depthPick, result),
+    ),
+  };
+  return { scene: scene as unknown as Scene, pickEllipsoid, globeRayPick };
+};
+
+const pick = (scene: Scene) =>
+  pickWorldPositionWithDepthBuffer(
+    scene,
+    new Cartesian2(10, 20),
+    new Cartesian3(),
+  );
+
+describe('pickWorldPositionWithDepthBuffer', () => {
+  it('prefers the depth buffer when it resolves a position', () => {
+    const { scene, globeRayPick, pickEllipsoid } = createScene({
+      depthPick: GEOMETRY,
+      globePick: TERRAIN,
+    });
+
+    expect(pick(scene)).toEqual(GEOMETRY);
+    expect(globeRayPick).not.toHaveBeenCalled();
+    expect(pickEllipsoid).not.toHaveBeenCalled();
+  });
+
+  // Regression: a translucent globe does not write to the depth buffer, so
+  // `pickPosition` returns nothing over plain terrain. Falling back to the
+  // ellipsoid put the zoom target kilometres below the visible ground, which
+  // inflated the measured distance and disabled the approach throttling.
+  it('falls back to the terrain ray, not the ellipsoid, without depth', () => {
+    const { scene, globeRayPick, pickEllipsoid } = createScene({
+      depthPick: undefined,
+      globePick: TERRAIN,
+    });
+
+    expect(pick(scene)).toEqual(TERRAIN);
+    expect(globeRayPick).toHaveBeenCalledOnce();
+    expect(pickEllipsoid).not.toHaveBeenCalled();
+  });
+
+  it('treats a zeroed depth pick as a miss', () => {
+    const { scene, globeRayPick } = createScene({
+      depthPick: Cartesian3.ZERO,
+      globePick: TERRAIN,
+    });
+
+    expect(pick(scene)).toEqual(TERRAIN);
+    expect(globeRayPick).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to the ellipsoid when the terrain ray misses', () => {
+    const { scene, pickEllipsoid } = createScene({
+      depthPick: undefined,
+      globePick: undefined,
+    });
+
+    expect(pick(scene)).toEqual(ELLIPSOID);
+    expect(pickEllipsoid).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to the ellipsoid when the globe is hidden', () => {
+    const { scene, globeRayPick, pickEllipsoid } = createScene({
+      depthPick: undefined,
+      globePick: TERRAIN,
+      isGlobeShown: false,
+    });
+
+    expect(pick(scene)).toEqual(ELLIPSOID);
+    expect(globeRayPick).not.toHaveBeenCalled();
+    expect(pickEllipsoid).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/src/features/controls/camera-controller.service.ts
+++ b/ui/src/features/controls/camera-controller.service.ts
@@ -11,20 +11,36 @@ import {
   Scene,
   ScreenSpaceMapCameraController,
   ScreenSpaceTiltOrbitCameraController,
-  ScreenSpaceZoomCameraController,
   Viewer,
 } from 'cesium';
 import { firstValueFrom } from 'rxjs';
 import { patchTiltNadirGimbalLock } from 'src/features/controls/patch-tilt-nadir-gimbal-lock';
 import { patchLegacyCameraController } from 'src/features/controls/patch-legacy-camera-controller';
+import { ApproachLimitedZoomCameraController } from 'src/features/controls/approach-limited-zoom.controller';
 import { isKnownScenePickingError } from 'src/services/pick.service';
+import { pickPositionWithRay } from 'src/cesiumutils';
 
 /**
- * Custom pick function that uses the depth buffer first (picks actual rendered geometry
- * and terrain), then falls back to the default ellipsoid/plane picking.
- * This ensures correct behavior both above and below terrain.
+ * Custom pick function that uses the depth buffer first (picks actual rendered
+ * geometry and terrain), then falls back to a math-based ray cast against the
+ * terrain, and only then to the ellipsoid.
+ *
+ * The terrain ray cast is essential, not just a nicety: `Scene.pickPosition`
+ * reads the depth buffer, which the globe does not write to while it is
+ * rendered translucently (background map opacity < 100%, or a transparent
+ * variant — see `LayerBackgroundController`/`globe.translucency`). Over plain
+ * terrain the depth pick then returns nothing.
+ *
+ * Falling straight through to `Camera.pickEllipsoid` in that case returns a
+ * point on the WGS84 ellipsoid, i.e. *below* the actual ground — by up to
+ * several kilometres in the Alps. Every consumer of this function measures the
+ * distance to the returned point, so the result is a distance that is far too
+ * large: the zoom controller's approach limiter then permits steps that are
+ * multiples of the real distance to the surface and the camera shoots through
+ * the (visible) terrain. Ray-casting the terrain first keeps the target on the
+ * surface the user actually sees, whatever the globe's opacity is.
  */
-function pickWorldPositionWithDepthBuffer(
+export function pickWorldPositionWithDepthBuffer(
   scene: Scene,
   windowPosition: Cartesian2,
   result: Cartesian3,
@@ -32,7 +48,7 @@ function pickWorldPositionWithDepthBuffer(
   // Try depth buffer first — this picks on actual rendered geometry/terrain.
   // `scene.pickPosition` can throw known/transient errors while tiles are
   // still loading (see `isKnownScenePickingError`); fall back to the
-  // ellipsoid pick instead of letting the exception abort the drag.
+  // ray-based picks instead of letting the exception abort the drag.
   try {
     const depthPick = scene.pickPosition(windowPosition, result);
     if (defined(depthPick) && !Cartesian3.equals(depthPick, Cartesian3.ZERO)) {
@@ -44,8 +60,13 @@ function pickWorldPositionWithDepthBuffer(
     }
   }
 
-  // Fall back to ellipsoid pick
-  return scene.camera.pickEllipsoid(windowPosition, scene.ellipsoid, result);
+  // Depth-buffer pick unavailable (most commonly: translucent globe).
+  // Intersect the terrain geometrically, and only use the ellipsoid if the
+  // globe is hidden or the ray misses it entirely.
+  return (
+    pickPositionWithRay(scene, windowPosition, result) ??
+    scene.camera.pickEllipsoid(windowPosition, scene.ellipsoid, result)
+  );
 }
 
 /**
@@ -66,7 +87,7 @@ export class CameraControllerService extends BaseService {
     ],
   });
 
-  readonly zoomController = new ScreenSpaceZoomCameraController({
+  readonly zoomController = new ApproachLimitedZoomCameraController({
     dragInputs: [{ button: MouseButton.RIGHT }],
   });
 
@@ -79,12 +100,21 @@ export class CameraControllerService extends BaseService {
     this.tiltController.useDragPosition = true;
     this.tiltController.orbitMagnitude = -2.0;
     this.tiltController.maximumOrbitVelocity = -CesiumMath.TWO_PI;
-    this.zoomController.zoomDistanceRatio = 0.15;
+
+    // A browser wheel notch (`deltaY = 100`) becomes `dz = 20` after
+    // `zoomSensitivity`, so one notch travels roughly
+    // `20 * zoomDistanceRatio * distance`, smoothed over `zoomAnimationDuration`.
+    // `0.1` puts a single notch at ~7% of the distance to the zoom target, which
+    // matches the legacy monolithic controller (`zoomFactor * 7.5°/notch`) and is
+    // noticeably calmer than Cesium's `0.4` default.
+    this.zoomController.zoomDistanceRatio = 0.1;
 
     // Use depth-buffer-aware picking for correct underground behavior.
     this.tiltController.pickWorldPosition = pickWorldPositionWithDepthBuffer;
-    this.zoomController.pickWorldPosition = pickWorldPositionWithDepthBuffer;
     this.panController.pickWorldPosition = pickWorldPositionWithDepthBuffer;
+    // The zoom controller resolves its own target from the tracked pointer
+    // position, so it takes the pick function through a dedicated property.
+    this.zoomController.pickGeometryPosition = pickWorldPositionWithDepthBuffer;
 
     // Fix CesiumJS's nadir/zenith heading-flip gimbal lock bug (see the
     // function doc for the full root-cause analysis and links).

--- a/ui/src/features/controls/control-zoom-debug.element.ts
+++ b/ui/src/features/controls/control-zoom-debug.element.ts
@@ -1,0 +1,375 @@
+import { css, html, nothing } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { consume } from '@lit/context';
+import {
+  Cartesian2,
+  Cartesian3,
+  Cartographic,
+  Cesium3DTileFeature,
+  Cesium3DTileset,
+  Entity,
+  Scene,
+  Viewer,
+} from 'cesium';
+import { CoreElement } from 'src/features/core';
+import { CesiumService } from 'src/services/cesium.service';
+import { CameraControllerService } from 'src/features/controls/camera-controller.service';
+import {
+  ZoomClamp,
+  ZoomTargetSource,
+} from 'src/features/controls/approach-limited-zoom.controller';
+import { isKnownScenePickingError } from 'src/services/pick.service';
+
+/** How often the HUD re-reads the scene, in milliseconds. */
+const SAMPLE_INTERVAL = 100;
+
+const TARGET_SOURCE_LABELS: Record<ZoomTargetSource, string> = {
+  geometry: 'depth buffer / terrain ray',
+  fallback: 'ray fallback (nothing hit)',
+  none: 'none',
+};
+
+const CLAMP_LABELS: Record<ZoomClamp, string> = {
+  none: 'unclamped',
+  maximumApproachRate: 'slowed — maximumApproachRate',
+  maximumApproachFraction: 'slowed — maximumApproachFraction',
+  minimumApproachStep: 'boosted — minimumApproachStep',
+  targetSeparation: 'nudged — targetSeparation',
+};
+
+interface ZoomDebugView {
+  readonly pickedObject: string;
+  readonly depthBuffer: string;
+  readonly targetSource: ZoomTargetSource;
+  readonly origin: string;
+  readonly distance: number;
+  readonly height: number | null;
+  readonly requestedStep: number;
+  readonly appliedStep: number;
+  readonly maximumStep: number;
+  readonly clamp: ZoomClamp;
+  readonly isZoomingIn: boolean;
+  readonly frameSeconds: number;
+  readonly zoomVelocity: number;
+  readonly velocityScale: number;
+}
+
+/**
+ * Debug overlay for the scroll-wheel zoom, enabled with the `zoomDebug` URL
+ * flag (e.g. `?zoomDebug`).
+ *
+ * It visualises what {@link ApproachLimitedZoomCameraController} decided for the
+ * most recent frame: which object the zoom is aimed at, how far away it is, how
+ * far CesiumJS wanted to move, and which of our limits — if any — changed that.
+ *
+ * See `docs/camera-zoom.md` for how this differs from stock CesiumJS.
+ */
+@customElement('control-zoom-debug')
+export class ControlZoomDebug extends CoreElement {
+  @consume({ context: CesiumService.context() })
+  accessor cesiumService!: CesiumService;
+
+  @consume({ context: CameraControllerService.context() })
+  accessor cameraControllerService!: CameraControllerService;
+
+  @state()
+  accessor view: ZoomDebugView | null = null;
+
+  private viewer: Viewer | null = null;
+  private removePostRenderListener: (() => void) | null = null;
+  private lastSampleTime = 0;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+
+    this.register(() => this.removePostRenderListener?.());
+    this.register(
+      this.cesiumService.viewer$.subscribe((viewer) => {
+        this.removePostRenderListener?.();
+        this.viewer = viewer;
+        this.removePostRenderListener =
+          viewer.scene.postRender.addEventListener(this.handlePostRender);
+      }),
+    );
+  }
+
+  private readonly handlePostRender = (): void => {
+    const viewer = this.viewer;
+    if (viewer === null) {
+      return;
+    }
+
+    const now = performance.now();
+    if (now - this.lastSampleTime < SAMPLE_INTERVAL) {
+      return;
+    }
+    this.lastSampleTime = now;
+
+    const { scene } = viewer;
+    const debug = this.cameraControllerService.zoomController.debug;
+    const origin = debug.zoomOrigin;
+
+    // Picking is expensive, so it runs at the sample rate rather than per frame.
+    const pickedObject = describePickedObject(scene, origin);
+    const depthBuffer = describeDepthBuffer(scene, origin);
+
+    const cartographic = Cartographic.fromCartesian(
+      scene.camera.positionWC,
+      scene.ellipsoid,
+    );
+    const terrainHeight =
+      cartographic === undefined
+        ? null
+        : (scene.globe?.getHeight(cartographic) ?? 0);
+
+    this.view = {
+      pickedObject,
+      depthBuffer,
+      targetSource: debug.targetSource,
+      origin: `${Math.round(origin.x)}, ${Math.round(origin.y)}`,
+      distance: debug.distance,
+      height:
+        cartographic === undefined || terrainHeight === null
+          ? null
+          : cartographic.height - terrainHeight,
+      requestedStep: debug.requestedStep,
+      appliedStep: debug.appliedStep,
+      maximumStep: debug.maximumStep,
+      clamp: debug.clamp,
+      isZoomingIn: debug.isZoomingIn,
+      frameSeconds: debug.frameSeconds,
+      zoomVelocity: debug.zoomVelocity,
+      velocityScale: debug.velocityScale,
+    };
+  };
+
+  readonly render = () => {
+    const view = this.view;
+    if (view === null) {
+      return nothing;
+    }
+
+    const { zoomController } = this.cameraControllerService;
+    const stepRatio =
+      view.distance > 0 ? (view.appliedStep / view.distance) * 100 : 0;
+
+    return html`
+      <h3>Zoom debug</h3>
+      <dl>
+        ${row('Picked object', view.pickedObject)}
+        ${row('Depth buffer', view.depthBuffer)}
+        ${row('Target source', TARGET_SOURCE_LABELS[view.targetSource])}
+        ${row('Zoom origin (px)', view.origin)}
+        ${row('Distance to target', formatMeters(view.distance))}
+        ${row('Height above terrain', formatMeters(view.height))}
+      </dl>
+      <dl>
+        ${row('Requested step', formatMeters(view.requestedStep))}
+        ${row('Applied step', formatMeters(view.appliedStep))}
+        ${row('Max step', formatMeters(view.maximumStep))}
+        ${row('Applied / distance', `${stepRatio.toFixed(2)} %`)}
+        ${row(
+          'Limit',
+          CLAMP_LABELS[view.clamp],
+          view.clamp === 'none' ? '' : 'is-active',
+        )}
+        ${row('Input this frame', view.isZoomingIn ? 'zooming in' : 'glide')}
+      </dl>
+      <dl>
+        ${row('Frame time', `${(view.frameSeconds * 1000).toFixed(1)} ms`)}
+        ${row('Banked velocity', `${formatMeters(view.zoomVelocity)}/s`)}
+        ${row(
+          'Velocity rescaled to',
+          `${(view.velocityScale * 100).toFixed(1)} %`,
+          view.velocityScale < 0.999 ? 'is-active' : '',
+        )}
+      </dl>
+      <dl>
+        ${row('zoomDistanceRatio', zoomController.zoomDistanceRatio.toFixed(3))}
+        ${row('zoomSensitivity', zoomController.zoomSensitivity.toFixed(3))}
+        ${row(
+          'maximumApproachRate',
+          `${zoomController.maximumApproachRate.toFixed(2)} /s`,
+        )}
+        ${row(
+          'maximumApproachFraction',
+          zoomController.maximumApproachFraction.toFixed(2),
+        )}
+        ${row(
+          'minimumApproachStep',
+          formatMeters(zoomController.minimumApproachStep),
+        )}
+      </dl>
+    `;
+  };
+
+  static readonly styles = css`
+    :host {
+      position: absolute;
+      bottom: 12px;
+      left: 12px;
+      z-index: 10;
+      width: 300px;
+      padding: 8px 10px;
+      border-radius: 4px;
+      background: rgba(0, 0, 0, 0.72);
+      color: #e9ecef;
+      font-family: ui-monospace, monospace;
+      font-size: 11px;
+      line-height: 1.5;
+      pointer-events: none;
+    }
+
+    h3 {
+      margin: 0 0 6px;
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #adb5bd;
+    }
+
+    dl {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 0 8px;
+      margin: 0;
+      padding: 6px 0 0;
+      border-top: 1px solid rgba(255, 255, 255, 0.12);
+    }
+
+    dl:first-of-type {
+      border-top: none;
+      padding-top: 0;
+    }
+
+    dt {
+      color: #adb5bd;
+      white-space: nowrap;
+    }
+
+    dd {
+      margin: 0;
+      text-align: right;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    dd.is-active {
+      color: #ffd43b;
+    }
+  `;
+}
+
+const row = (label: string, value: string, valueClass = '') => html`
+  <dt>${label}</dt>
+  <dd class=${valueClass}>${value}</dd>
+`;
+
+const formatMeters = (value: number | null): string => {
+  if (value === null || Number.isNaN(value)) {
+    return '—';
+  }
+  const absolute = Math.abs(value);
+  if (absolute >= 1000) {
+    return `${(value / 1000).toFixed(2)} km`;
+  }
+  if (absolute >= 1) {
+    return `${value.toFixed(2)} m`;
+  }
+  return `${(value * 100).toFixed(2)} cm`;
+};
+
+/**
+ * Names whatever sits under the zoom origin. CesiumJS's `scene.pick` ignores the
+ * globe, so terrain is detected separately via a ray/globe intersection.
+ */
+function describePickedObject(scene: Scene, position: Cartesian2): string {
+  let picked: unknown;
+  try {
+    picked = scene.pick(position);
+  } catch (e) {
+    if (!isKnownScenePickingError(e)) {
+      throw e;
+    }
+    return 'unavailable (tiles loading)';
+  }
+
+  if (picked !== undefined && picked !== null) {
+    return describePrimitive(picked);
+  }
+
+  const ray = scene.camera.getPickRay(position);
+  if (ray !== undefined && scene.globe?.pick(ray, scene) !== undefined) {
+    return 'Terrain (globe)';
+  }
+
+  return 'nothing (sky)';
+}
+
+/**
+ * Reports whether `Scene.pickPosition` can resolve the zoom target, and why not
+ * when it cannot.
+ *
+ * A translucent globe does not write to the depth buffer, so over plain terrain
+ * the depth pick yields nothing and the zoom target has to come from the
+ * terrain ray cast instead (see `pickWorldPositionWithDepthBuffer`). Before that
+ * fallback existed, the target dropped to the WGS84 ellipsoid and the zoom
+ * throttling effectively stopped working.
+ */
+function describeDepthBuffer(scene: Scene, position: Cartesian2): string {
+  const isGlobeTranslucent = scene.globe?.translucency?.enabled === true;
+  let hasDepth = false;
+  try {
+    const depthPick = scene.pickPosition(position);
+    hasDepth =
+      depthPick !== undefined && !Cartesian3.equals(depthPick, Cartesian3.ZERO);
+  } catch (e) {
+    if (!isKnownScenePickingError(e)) {
+      throw e;
+    }
+  }
+
+  if (hasDepth) {
+    return isGlobeTranslucent ? 'available (globe translucent)' : 'available';
+  }
+  return isGlobeTranslucent
+    ? 'unavailable — globe translucent, using terrain ray'
+    : 'unavailable — using terrain ray';
+}
+
+function describePrimitive(picked: unknown): string {
+  if (picked instanceof Cesium3DTileFeature) {
+    const name =
+      picked.getProperty('name') ?? picked.getProperty('Name') ?? undefined;
+    const tileset = describeTileset(picked.primitive);
+    return name === undefined
+      ? `3D Tile feature — ${tileset}`
+      : `3D Tile feature "${name}" — ${tileset}`;
+  }
+
+  const primitive = (picked as { primitive?: unknown }).primitive;
+  const id = (picked as { id?: unknown }).id;
+
+  if (id instanceof Entity) {
+    return `Entity "${id.name ?? id.id}"`;
+  }
+  if (primitive instanceof Cesium3DTileset) {
+    return `Tileset — ${describeTileset(primitive)}`;
+  }
+  if (primitive !== undefined && primitive !== null) {
+    return (primitive as object).constructor.name;
+  }
+  return (picked as object).constructor.name;
+}
+
+function describeTileset(tileset: unknown): string {
+  if (!(tileset instanceof Cesium3DTileset)) {
+    return 'unknown tileset';
+  }
+  const url = tileset.resource?.url;
+  if (typeof url !== 'string') {
+    return 'unknown tileset';
+  }
+  return url.split('/').filter(Boolean).slice(-2).join('/');
+}

--- a/ui/src/features/controls/controls.module.ts
+++ b/ui/src/features/controls/controls.module.ts
@@ -1,2 +1,3 @@
 import './control-2d.element';
 import './control-compass.element';
+import './control-zoom-debug.element';

--- a/ui/src/ngm-app.ts
+++ b/ui/src/ngm-app.ts
@@ -27,6 +27,7 @@ import { setupViewer } from './viewer';
 import {
   getCameraView,
   getTopicOrProject,
+  getZoomDebugParam,
   getZoomToPosition,
   rewriteParams,
   setCesiumToolbarParam,
@@ -136,6 +137,9 @@ export class NgmApp extends LitElementI18n {
 
   @state()
   accessor showCesiumToolbar = false;
+
+  @state()
+  accessor showZoomDebug = getZoomDebugParam();
 
   @query('ngm-cam-configuration')
   accessor camConfigElement;
@@ -585,6 +589,10 @@ export class NgmApp extends LitElementI18n {
           ${when(
             this.showCesiumToolbar,
             () => html`<cesium-toolbar></cesium-toolbar>`,
+          )}
+          ${when(
+            this.showZoomDebug,
+            () => html`<control-zoom-debug></control-zoom-debug>`,
           )}
         </div>
       </main>

--- a/ui/src/permalink.ts
+++ b/ui/src/permalink.ts
@@ -154,6 +154,10 @@ export function setCesiumToolbarParam(value: boolean) {
   setURLSearchParams(params);
 }
 
+export function getZoomDebugParam(): boolean {
+  return getURLSearchParams().has('zoomDebug');
+}
+
 export function syncStoredView(
   stored: string,
   skipParams: string[] = [


### PR DESCRIPTION
Scroll-wheel zoom overshot whatever it was aimed at: a single hard flick could put the camera behind a building or through the terrain, and zooming always went to the centre of the screen rather than to the cursor.

Both are defects in cesium@1.144.0's ScreenSpaceZoomCameraController, not gaps in its feature set, so this is a temporary patch rather than a product customisation:

- The zoom step is `dz * distance * zoomDistanceRatio` and nothing bounds it against the distance to the target, so a large delta on a slow frame moves the camera past it. The knobs that sound like they would cap this do not: `maximumZoomVelocity` never limits the speed and `maximumZoomDistance` never bounds the camera. There is no supported configuration that avoids the overshoot.
- `usePointerPosition` is declared and documented but `update()` reads an unassigned `useDragPosition`, so it is a no-op. Even if it were read, the tracked pointer position is never updated: the controller registers its MOUSE_MOVE handler and `registerDragInputBindings()` then silently overwrites it, since a ScreenSpaceEventHandler keeps one action per (type, modifier) pair.
- The no-target fallback distance is computed against the equatorial radius and goes negative outside the tropics, which inverts the zoom direction over Switzerland.

`ApproachLimitedZoomCameraController` subclasses the stock controller and intervenes only at those points, reusing CesiumJS's own damping, inertia and input bindings. It caps each frame's step to a fraction of the distance to the picked target, rescales the banked glide velocity so the damped tail cannot overshoot either, and tracks the pointer on its own event handler so zoom-to-cursor works.

Also makes the target pick terrain-aware: `scene.pickPosition` returns nothing while the globe is translucent, and falling through to the ellipsoid reports a surface kilometres below the visible ground in the Alps, which inflates the distance the limiter is derived from.

A debug HUD is available behind the `?zoomDebug` URL flag.

This override is meant to be removed. `docs/camera-zoom.md` documents the upstream defects, the acceptance checks a future CesiumJS release has to pass, and the step-by-step removal. The test "is not bounded by the stock controller, which does overshoot" is the tripwire: it asserts that the *stock* controller still overshoots, so it starts failing the moment upstream fixes the main defect.

Refs #2058