### PR TITLE
stop camera controller exceptions from silently freezing the render loop

### DIFF
--- a/ui/src/cesiumutils.ts
+++ b/ui/src/cesiumutils.ts
@@ -20,7 +20,7 @@ import {
 } from 'cesium';
 import type { GeometryTypes } from './toolbox/interfaces';
 import earcut from 'earcut';
-import { isKnownScenePickingError } from 'src/services/pick.service';
+import { handleScenePickingError } from 'src/services/pick.service';
 
 const julianDate = new JulianDate();
 
@@ -54,11 +54,11 @@ export function pickCenterOnEllipsoid(scene: Scene): Cartesian3 | undefined {
  *
  * `Scene.pickPosition` can throw while some tiles/primitives are not yet
  * fully loaded, or after the scene/camera has been destroyed mid-pick (see
- * {@link isKnownScenePickingError}). These failures are expected/transient
- * and must not propagate, since callers of this function are often plain
- * RxJS subscribe callbacks: an uncaught exception there would permanently
- * terminate the subscription (e.g. breaking the tilt/orbit axis indicator
- * for the rest of the session after a single failed pick).
+ * {@link handleScenePickingError}). These failures must not propagate, since
+ * callers of this function are often plain RxJS subscribe callbacks: an
+ * uncaught exception there would permanently terminate the subscription
+ * (e.g. breaking the tilt/orbit axis indicator for the rest of the session
+ * after a single failed pick).
  *
  * `Scene.pickPosition` also relies on the depth buffer, which isn't
  * reliably populated while the globe is rendered translucently (e.g. the
@@ -91,10 +91,8 @@ function tryPickScenePosition(
   try {
     return scene.pickPosition(windowPosition) ?? undefined;
   } catch (e) {
-    if (isKnownScenePickingError(e)) {
-      return undefined;
-    }
-    throw e;
+    handleScenePickingError(e);
+    return undefined;
   }
 }
 

--- a/ui/src/features/controls/approach-limited-zoom.controller.ts
+++ b/ui/src/features/controls/approach-limited-zoom.controller.ts
@@ -9,6 +9,7 @@ import {
   ScreenSpaceEventType,
   ScreenSpaceZoomCameraController,
 } from 'cesium';
+import { handleScenePickingError } from 'src/services/pick.service';
 
 const scratchCameraPosition = new Cartesian3();
 const scratchToTarget = new Cartesian3();
@@ -273,26 +274,45 @@ export class ApproachLimitedZoomCameraController extends ScreenSpaceZoomCameraCo
 
     // The `windowPosition` handed in by CesiumJS is unusable (see the class
     // doc), so the tracked pointer position is used instead.
+    //
+    // This runs on every zoom frame and is invoked directly by CesiumJS
+    // (`ScreenSpaceZoomCameraController.update()`), with no try/catch of its
+    // own — the same call site whose unguarded `Scene.pickPosition()` failure
+    // used to freeze the whole UI (see `handleScenePickingError`). Both picks
+    // below (`pickGeometryPosition`, typically `pickWorldPositionWithDepthBuffer`,
+    // and the terrain-height lookup in `pickFallbackPosition`) can throw while
+    // tiles are still loading or the scene is mid-teardown, so the whole hook
+    // is wrapped defensively: any pick error degrades to "no target"
+    // (CesiumJS's own no-target fallback then applies) instead of aborting the
+    // frame. `update()` (see below) is itself also wrapped, as a last-resort
+    // safety net for anything not caught here.
     this.pickWorldPosition = (
       scene: Scene,
       _windowPosition: Cartesian2,
       result: Cartesian3,
     ): Cartesian3 | undefined => {
-      const geometry = this.pickGeometryPosition(
-        scene,
-        this.zoomOrigin,
-        result,
-      );
-      if (geometry !== undefined) {
-        this.debug.targetSource = 'geometry';
-        this.target = geometry;
-        return geometry;
-      }
+      try {
+        const geometry = this.pickGeometryPosition(
+          scene,
+          this.zoomOrigin,
+          result,
+        );
+        if (geometry !== undefined) {
+          this.debug.targetSource = 'geometry';
+          this.target = geometry;
+          return geometry;
+        }
 
-      const fallback = pickFallbackPosition(scene, this.zoomOrigin, result);
-      this.debug.targetSource = fallback === undefined ? 'none' : 'fallback';
-      this.target = fallback;
-      return fallback;
+        const fallback = pickFallbackPosition(scene, this.zoomOrigin, result);
+        this.debug.targetSource = fallback === undefined ? 'none' : 'fallback';
+        this.target = fallback;
+        return fallback;
+      } catch (e) {
+        handleScenePickingError(e);
+        this.debug.targetSource = 'none';
+        this.target = undefined;
+        return undefined;
+      }
     };
   }
 
@@ -336,6 +356,30 @@ export class ApproachLimitedZoomCameraController extends ScreenSpaceZoomCameraCo
   }
 
   update(scene: Scene, time: JulianDate): void {
+    // Any uncaught exception here would be thrown from inside
+    // `ControllerHost.update()`, which CesiumJS's `CesiumWidget` render loop
+    // calls *before* the internal try/catch that raises `Scene#renderError`.
+    // Such an exception instead reaches the render loop's own outer
+    // try/catch, which permanently stops calling `requestAnimationFrame` —
+    // silently, since this app sets `showRenderLoopErrors: false` — freezing
+    // the map forever with no console output. See
+    // `reorthonormalizeCameraFrame` in `patch-tilt-nadir-gimbal-lock.ts` for
+    // the full mechanism (discovered via exactly this failure mode). Guard
+    // against it here too so any future/unknown throw becomes a single
+    // skipped frame plus a visible error instead of a silent, unrecoverable
+    // freeze.
+    try {
+      this.updateUnsafe(scene, time);
+    } catch (e) {
+      console.error(
+        '[ApproachLimitedZoomCameraController] update() threw and was ' +
+          'skipped for this frame to avoid silently freezing the render loop:',
+        e,
+      );
+    }
+  }
+
+  private updateUnsafe(scene: Scene, time: JulianDate): void {
     this.resolveZoomOrigin(scene);
 
     // Must be read *before* `super.update()`, which consumes and clears it.

--- a/ui/src/features/controls/camera-controller.service.ts
+++ b/ui/src/features/controls/camera-controller.service.ts
@@ -17,7 +17,7 @@ import { firstValueFrom } from 'rxjs';
 import { patchTiltNadirGimbalLock } from 'src/features/controls/patch-tilt-nadir-gimbal-lock';
 import { patchLegacyCameraController } from 'src/features/controls/patch-legacy-camera-controller';
 import { ApproachLimitedZoomCameraController } from 'src/features/controls/approach-limited-zoom.controller';
-import { isKnownScenePickingError } from 'src/services/pick.service';
+import { handleScenePickingError } from 'src/services/pick.service';
 import { pickPositionWithRay } from 'src/cesiumutils';
 
 /**
@@ -46,18 +46,16 @@ export function pickWorldPositionWithDepthBuffer(
   result: Cartesian3,
 ): Cartesian3 | undefined {
   // Try depth buffer first — this picks on actual rendered geometry/terrain.
-  // `scene.pickPosition` can throw known/transient errors while tiles are
-  // still loading (see `isKnownScenePickingError`); fall back to the
-  // ray-based picks instead of letting the exception abort the drag.
+  // `scene.pickPosition` can throw while tiles are still loading (see
+  // `handleScenePickingError`); fall back to the ray-based picks instead of
+  // letting the exception abort the drag.
   try {
     const depthPick = scene.pickPosition(windowPosition, result);
     if (defined(depthPick) && !Cartesian3.equals(depthPick, Cartesian3.ZERO)) {
       return depthPick;
     }
   } catch (e) {
-    if (!isKnownScenePickingError(e)) {
-      throw e;
-    }
+    handleScenePickingError(e);
   }
 
   // Depth-buffer pick unavailable (most commonly: translucent globe).

--- a/ui/src/features/controls/control-zoom-debug.element.ts
+++ b/ui/src/features/controls/control-zoom-debug.element.ts
@@ -18,7 +18,7 @@ import {
   ZoomClamp,
   ZoomTargetSource,
 } from 'src/features/controls/approach-limited-zoom.controller';
-import { isKnownScenePickingError } from 'src/services/pick.service';
+import { handleScenePickingError } from 'src/services/pick.service';
 
 /** How often the HUD re-reads the scene, in milliseconds. */
 const SAMPLE_INTERVAL = 100;
@@ -289,9 +289,7 @@ function describePickedObject(scene: Scene, position: Cartesian2): string {
   try {
     picked = scene.pick(position);
   } catch (e) {
-    if (!isKnownScenePickingError(e)) {
-      throw e;
-    }
+    handleScenePickingError(e);
     return 'unavailable (tiles loading)';
   }
 
@@ -325,9 +323,7 @@ function describeDepthBuffer(scene: Scene, position: Cartesian2): string {
     hasDepth =
       depthPick !== undefined && !Cartesian3.equals(depthPick, Cartesian3.ZERO);
   } catch (e) {
-    if (!isKnownScenePickingError(e)) {
-      throw e;
-    }
+    handleScenePickingError(e);
   }
 
   if (hasDepth) {

--- a/ui/src/features/controls/patch-tilt-nadir-gimbal-lock.ts
+++ b/ui/src/features/controls/patch-tilt-nadir-gimbal-lock.ts
@@ -75,184 +75,291 @@ export function patchTiltNadirGimbalLock(
 ): void {
   const internals = controller as unknown as TiltControllerInternals;
 
-  controller.tilt = (
-    camera: Camera,
-    target: Cartesian3,
-    axis: Cartesian3,
-    amount: number,
-    dt: number,
-    _ellipsoid: Ellipsoid = Ellipsoid.default,
-  ): void => {
-    const dampened = internals._tiltDampenedResults;
+  controller.tilt = guardCameraMutator(
+    'tilt',
+    (
+      camera: Camera,
+      target: Cartesian3,
+      axis: Cartesian3,
+      amount: number,
+      dt: number,
+      _ellipsoid: Ellipsoid = Ellipsoid.default,
+    ): void => {
+      const dampened = internals._tiltDampenedResults;
 
-    if (
-      globalThis.Math.abs(dampened.velocity) < internals.minimumTiltVelocity
-    ) {
-      dampened.velocity = 0.0;
+      if (
+        globalThis.Math.abs(dampened.velocity) < internals.minimumTiltVelocity
+      ) {
+        dampened.velocity = 0.0;
+      }
+
+      // Apply inertia
+      if (!internals.isDragging && controller.dampingEnabled) {
+        amount += dampened.velocity * dt;
+      }
+
+      if (amount === 0.0) {
+        return;
+      }
+
+      const currentTiltAngle = Cartesian3.angleBetween(camera.direction, axis);
+
+      // Avoid large deltas when the sign is close to flipping, which can happen
+      // when the camera is looking straight down at the ellipsoid.
+      if (
+        (currentTiltAngle < CesiumMath.PI_OVER_TWO && amount > 0.0) ||
+        (currentTiltAngle > CesiumMath.PI_OVER_TWO && amount < 0.0)
+      ) {
+        amount *= globalThis.Math.abs(globalThis.Math.sin(currentTiltAngle));
+      }
+
+      const targetTiltAngle = currentTiltAngle + amount;
+
+      const maxSpeed = controller.dampingEnabled
+        ? controller.maximumTiltVelocity * controller.tiltMagnitude
+        : undefined;
+      const smoothTime = controller.dampingEnabled
+        ? controller.tiltAnimationDuration
+        : undefined;
+
+      CesiumMath.smoothDamp(
+        currentTiltAngle,
+        targetTiltAngle,
+        dampened.velocity,
+        dt,
+        maxSpeed,
+        smoothTime,
+        dampened,
+      );
+
+      const theta = dampened.value - currentTiltAngle;
+      const rotation = Matrix3.fromQuaternion(
+        Quaternion.fromAxisAngle(
+          camera.rightWC,
+          -theta,
+          scratchRotationQuaternion,
+        ),
+        scratchRotationMatrix,
+      );
+
+      const offset = Cartesian3.subtract(
+        camera.position,
+        target,
+        scratchOffset,
+      );
+      const t = Cartesian3.dot(offset, camera.directionWC);
+      const lookOffset = Cartesian3.multiplyByScalar(
+        camera.directionWC,
+        t,
+        scratchLookOffset,
+      );
+      const lookTarget = Cartesian3.subtract(
+        camera.position,
+        lookOffset,
+        scratchLookTarget,
+      );
+      const rotatedOffset = Matrix3.multiplyByVector(
+        rotation,
+        lookOffset,
+        scratchRotatedOffset,
+      );
+
+      Cartesian3.add(lookTarget, rotatedOffset, camera.position);
+
+      // Instead of camera.lookAtWorldPosition(lookTarget, ellipsoid) — which
+      // reconstructs right/up via cross(direction, worldUp) and degenerates at
+      // the pole — rotate the existing direction/up vectors directly by the
+      // same rotation matrix, then re-orthonormalize. This mirrors what
+      // Camera.prototype.rotate() does and stays continuous through nadir.
+      Matrix3.multiplyByVector(rotation, camera.direction, camera.direction);
+      Matrix3.multiplyByVector(rotation, camera.up, camera.up);
+      reorthonormalizeCameraFrame(camera);
+    },
+  );
+
+  controller.orbit = guardCameraMutator(
+    'orbit',
+    (
+      camera: Camera,
+      target: Cartesian3,
+      axis: Cartesian3,
+      amount: number,
+      dt: number,
+      ellipsoid: Ellipsoid = Ellipsoid.default,
+    ): void => {
+      const dampened = internals._orbitDampenedResults;
+
+      const enu = Transforms.eastNorthUpToFixedFrame(
+        target,
+        ellipsoid,
+        scratchOrbitTargetEnu,
+      );
+      const east = Matrix4.multiplyByPointAsVector(
+        enu,
+        Cartesian3.UNIT_X,
+        scratchOrbitTargetEast,
+      );
+      const currentOrbitAngle = Cartesian3.angleBetween(
+        camera.directionWC,
+        east,
+      );
+
+      if (
+        globalThis.Math.abs(dampened.velocity) < internals.minimumOrbitVelocity
+      ) {
+        dampened.velocity = 0.0;
+      }
+
+      // Apply inertia
+      if (!internals.isDragging && controller.dampingEnabled) {
+        amount += dampened.velocity * dt;
+      }
+
+      if (amount === 0.0) {
+        return;
+      }
+
+      const targetOrbitAngle = currentOrbitAngle + amount;
+
+      const maxSpeed = controller.dampingEnabled
+        ? controller.maximumOrbitVelocity * controller.orbitMagnitude
+        : undefined;
+      const smoothTime = controller.dampingEnabled
+        ? controller.orbitAnimationDuration
+        : undefined;
+
+      CesiumMath.smoothDamp(
+        currentOrbitAngle,
+        targetOrbitAngle,
+        dampened.velocity,
+        dt,
+        maxSpeed,
+        smoothTime,
+        dampened,
+      );
+
+      const rho = dampened.value - currentOrbitAngle;
+      const rotation = Matrix3.fromQuaternion(
+        Quaternion.fromAxisAngle(axis, -rho, scratchOrbitRotationQuaternion),
+        scratchOrbitRotationMatrix,
+      );
+
+      const targetOffset = Cartesian3.subtract(
+        camera.positionWC,
+        target,
+        scratchOrbitTargetOffset,
+      );
+
+      const rotatedTargetOffset = Matrix3.multiplyByVector(
+        rotation,
+        targetOffset,
+        scratchOrbitRotatedTargetOffset,
+      );
+
+      Cartesian3.add(target, rotatedTargetOffset, camera.position);
+
+      // As with tilt() above, avoid camera.lookAtWorldPosition() here — it
+      // reconstructs right/up via cross(direction, worldUp) and degenerates at
+      // the pole. Rotate the existing direction/up vectors directly instead.
+      Matrix3.multiplyByVector(rotation, camera.direction, camera.direction);
+      Matrix3.multiplyByVector(rotation, camera.up, camera.up);
+      reorthonormalizeCameraFrame(camera);
+    },
+  );
+}
+
+/**
+ * Signature shared by `ScreenSpaceTiltOrbitCameraController#tilt`/`#orbit`.
+ */
+type CameraMutator = (
+  camera: Camera,
+  target: Cartesian3,
+  axis: Cartesian3,
+  amount: number,
+  dt: number,
+  ellipsoid?: Ellipsoid,
+) => void;
+
+/**
+ * Wraps a `tilt()`/`orbit()` implementation so that any exception it throws is
+ * logged and swallowed instead of propagating into `ControllerHost.update()`.
+ *
+ * An uncaught exception there is fatal in a way that is easy to miss: it is
+ * thrown *before* CesiumJS's own per-frame try/catch (`Scene#renderError`)
+ * gets a chance to see it (see `reorthonormalizeCameraFrame`'s doc for the
+ * full mechanism), so it instead reaches `CesiumWidget`'s render-loop
+ * try/catch, which permanently stops calling `requestAnimationFrame` — with
+ * no console output at all when `showRenderLoopErrors` is `false`, as it is in
+ * this app. Guarding every custom camera-mutating function this way turns
+ * that silent, unrecoverable freeze into a single skipped frame plus a
+ * visible error.
+ */
+function guardCameraMutator(name: string, fn: CameraMutator): CameraMutator {
+  return (camera, target, axis, amount, dt, ellipsoid) => {
+    try {
+      fn(camera, target, axis, amount, dt, ellipsoid);
+    } catch (e) {
+      console.error(
+        `[patchTiltNadirGimbalLock] ${name}() threw and was skipped for this frame ` +
+          'to avoid silently freezing the render loop:',
+        e,
+      );
     }
-
-    // Apply inertia
-    if (!internals.isDragging && controller.dampingEnabled) {
-      amount += dampened.velocity * dt;
-    }
-
-    if (amount === 0.0) {
-      return;
-    }
-
-    const currentTiltAngle = Cartesian3.angleBetween(camera.direction, axis);
-
-    // Avoid large deltas when the sign is close to flipping, which can happen
-    // when the camera is looking straight down at the ellipsoid.
-    if (
-      (currentTiltAngle < CesiumMath.PI_OVER_TWO && amount > 0.0) ||
-      (currentTiltAngle > CesiumMath.PI_OVER_TWO && amount < 0.0)
-    ) {
-      amount *= globalThis.Math.abs(globalThis.Math.sin(currentTiltAngle));
-    }
-
-    const targetTiltAngle = currentTiltAngle + amount;
-
-    const maxSpeed = controller.dampingEnabled
-      ? controller.maximumTiltVelocity * controller.tiltMagnitude
-      : undefined;
-    const smoothTime = controller.dampingEnabled
-      ? controller.tiltAnimationDuration
-      : undefined;
-
-    CesiumMath.smoothDamp(
-      currentTiltAngle,
-      targetTiltAngle,
-      dampened.velocity,
-      dt,
-      maxSpeed,
-      smoothTime,
-      dampened,
-    );
-
-    const theta = dampened.value - currentTiltAngle;
-    const rotation = Matrix3.fromQuaternion(
-      Quaternion.fromAxisAngle(
-        camera.rightWC,
-        -theta,
-        scratchRotationQuaternion,
-      ),
-      scratchRotationMatrix,
-    );
-
-    const offset = Cartesian3.subtract(camera.position, target, scratchOffset);
-    const t = Cartesian3.dot(offset, camera.directionWC);
-    const lookOffset = Cartesian3.multiplyByScalar(
-      camera.directionWC,
-      t,
-      scratchLookOffset,
-    );
-    const lookTarget = Cartesian3.subtract(
-      camera.position,
-      lookOffset,
-      scratchLookTarget,
-    );
-    const rotatedOffset = Matrix3.multiplyByVector(
-      rotation,
-      lookOffset,
-      scratchRotatedOffset,
-    );
-
-    Cartesian3.add(lookTarget, rotatedOffset, camera.position);
-
-    // Instead of camera.lookAtWorldPosition(lookTarget, ellipsoid) — which
-    // reconstructs right/up via cross(direction, worldUp) and degenerates at
-    // the pole — rotate the existing direction/up vectors directly by the
-    // same rotation matrix, then re-orthogonalize. This mirrors what
-    // Camera.prototype.rotate() does and stays continuous through nadir.
-    Matrix3.multiplyByVector(rotation, camera.direction, camera.direction);
-    Matrix3.multiplyByVector(rotation, camera.up, camera.up);
-    Cartesian3.cross(camera.direction, camera.up, camera.right);
-    Cartesian3.cross(camera.right, camera.direction, camera.up);
   };
+}
 
-  controller.orbit = (
-    camera: Camera,
-    target: Cartesian3,
-    axis: Cartesian3,
-    amount: number,
-    dt: number,
-    ellipsoid: Ellipsoid = Ellipsoid.default,
-  ): void => {
-    const dampened = internals._orbitDampenedResults;
+/**
+ * Re-normalizes and re-orthogonalizes the camera's `direction`/`up`/`right`
+ * basis in place after `tilt()`/`orbit()` rotate it directly.
+ *
+ * `Matrix3.multiplyByVector` and `Cartesian3.cross` preserve unit length and
+ * orthogonality only in exact arithmetic. In floating point, every frame's
+ * rotation introduces a tiny rounding error, and neither `tilt()` nor
+ * `orbit()` ever corrected for it (the "re-orthogonalize" comment was
+ * aspirational — no `normalize()` call actually existed). Over many frames of
+ * sustained panning/orbiting the basis drifts further from orthonormal each
+ * time, until some later, unrelated piece of CesiumJS's own per-frame camera
+ * math (which assumes a unit/orthogonal basis) hits a degenerate vector and
+ * throws a `DeveloperError`.
+ *
+ * That throw happens inside `ControllerHost.update()`, which CesiumJS's
+ * `CesiumWidget` render loop calls *before* the internal try/catch that raises
+ * `Scene#renderError` (see `Scene.prototype.render`/`tryAndCatchError` in
+ * `@cesium/engine`). An error there is instead caught by the render loop's own
+ * outer `try/catch`, which permanently stops calling `requestAnimationFrame`
+ * (silently, since this app sets `showRenderLoopErrors: false` and the loop
+ * itself never logs) — freezing the map forever with no console output, while
+ * the rest of the page (built on separate DOM/RxJS state) stays fully
+ * responsive. See https://github.com/swisstopo/swissgeol-viewer-suite/issues/2058.
+ *
+ * `Cartesian3.normalize` itself throws a `DeveloperError` on a zero-length
+ * input. That should no longer happen now that drift is corrected every
+ * frame, but since a throw here would reproduce the exact freeze this
+ * function exists to prevent, each normalize is skipped (keeping the
+ * pre-rotation vector) rather than allowed to throw if a component ever does
+ * degenerate to zero.
+ */
+function reorthonormalizeCameraFrame(camera: Camera): void {
+  if (!safeNormalize(camera.direction)) {
+    return;
+  }
+  Cartesian3.cross(camera.direction, camera.up, camera.right);
+  if (!safeNormalize(camera.right)) {
+    return;
+  }
+  Cartesian3.cross(camera.right, camera.direction, camera.up);
+  safeNormalize(camera.up);
+}
 
-    const enu = Transforms.eastNorthUpToFixedFrame(
-      target,
-      ellipsoid,
-      scratchOrbitTargetEnu,
-    );
-    const east = Matrix4.multiplyByPointAsVector(
-      enu,
-      Cartesian3.UNIT_X,
-      scratchOrbitTargetEast,
-    );
-    const currentOrbitAngle = Cartesian3.angleBetween(camera.directionWC, east);
-
-    if (
-      globalThis.Math.abs(dampened.velocity) < internals.minimumOrbitVelocity
-    ) {
-      dampened.velocity = 0.0;
-    }
-
-    // Apply inertia
-    if (!internals.isDragging && controller.dampingEnabled) {
-      amount += dampened.velocity * dt;
-    }
-
-    if (amount === 0.0) {
-      return;
-    }
-
-    const targetOrbitAngle = currentOrbitAngle + amount;
-
-    const maxSpeed = controller.dampingEnabled
-      ? controller.maximumOrbitVelocity * controller.orbitMagnitude
-      : undefined;
-    const smoothTime = controller.dampingEnabled
-      ? controller.orbitAnimationDuration
-      : undefined;
-
-    CesiumMath.smoothDamp(
-      currentOrbitAngle,
-      targetOrbitAngle,
-      dampened.velocity,
-      dt,
-      maxSpeed,
-      smoothTime,
-      dampened,
-    );
-
-    const rho = dampened.value - currentOrbitAngle;
-    const rotation = Matrix3.fromQuaternion(
-      Quaternion.fromAxisAngle(axis, -rho, scratchOrbitRotationQuaternion),
-      scratchOrbitRotationMatrix,
-    );
-
-    const targetOffset = Cartesian3.subtract(
-      camera.positionWC,
-      target,
-      scratchOrbitTargetOffset,
-    );
-
-    const rotatedTargetOffset = Matrix3.multiplyByVector(
-      rotation,
-      targetOffset,
-      scratchOrbitRotatedTargetOffset,
-    );
-
-    Cartesian3.add(target, rotatedTargetOffset, camera.position);
-
-    // As with tilt() above, avoid camera.lookAtWorldPosition() here — it
-    // reconstructs right/up via cross(direction, worldUp) and degenerates at
-    // the pole. Rotate the existing direction/up vectors directly instead.
-    Matrix3.multiplyByVector(rotation, camera.direction, camera.direction);
-    Matrix3.multiplyByVector(rotation, camera.up, camera.up);
-    Cartesian3.cross(camera.direction, camera.up, camera.right);
-    Cartesian3.cross(camera.right, camera.direction, camera.up);
-  };
+/**
+ * Normalizes `vector` in place, returning whether it was non-degenerate
+ * (finite and non-zero) and therefore safe to normalize at all.
+ */
+function safeNormalize(vector: Cartesian3): boolean {
+  const magnitude = Cartesian3.magnitude(vector);
+  if (!Number.isFinite(magnitude) || magnitude === 0) {
+    return false;
+  }
+  Cartesian3.divideByScalar(vector, magnitude, vector);
+  return true;
 }

--- a/ui/src/services/pick.service.ts
+++ b/ui/src/services/pick.service.ts
@@ -11,37 +11,28 @@ import { BaseService } from 'src/services/base.service';
 import { CesiumService } from 'src/services/cesium.service';
 
 /**
- * Error messages that Cesium's `Scene.pickPosition` can throw while some
- * tiles/primitives are not yet fully loaded, or after the scene/camera has
- * been destroyed mid-pick. These are expected/transient and should fall back
- * to the less-accurate math-based pick rather than propagate as an uncaught
- * exception (which would otherwise abort an in-progress drag).
+ * `Scene.pickPosition` (and `Scene.pick`) can throw while some tiles/
+ * primitives are not yet fully loaded, or after the scene/camera has been
+ * destroyed mid-pick. The exact error text for these failures is unstable —
+ * it differs by browser engine and has even changed across Firefox versions/
+ * builds for the same underlying condition (observed: "Can't access property
+ * _target, v3 is undefined", "can't access property \"_target\", v is
+ * undefined", "Cannot read properties of undefined (reading '_target')",
+ * ...). Matching on that text is therefore a losing battle.
  *
- * The `_target` message wording differs by browser engine:
- * - Firefox: "Can't access property _target, v3 is undefined"
- * - Chrome/Edge (V8): "Cannot read properties of undefined (reading '_target')"
- *
- * TODO: This matches on hardcoded, engine-specific `Error#toString()` wording,
- * which is inherently fragile — it can silently stop matching (or need new
- * variants) after a browser engine or CesiumJS upgrade changes the exact
- * message text. Re-verify these suffixes when bumping Cesium or when new
- * "uncaught exception during pick" reports come in.
+ * Instead, every pick call site treats *any* exception from these functions
+ * as recoverable: log it (so it's never silent — an uncaught exception here
+ * has previously frozen the whole render loop with zero console output, see
+ * git history) and degrade gracefully instead of propagating the exception —
+ * typically by falling back to a less accurate, math-based pick, but exactly
+ * what "degrade gracefully" means (fallback pick, `undefined`/no target, a
+ * placeholder debug string, ...) is up to the caller.
  */
-const KNOWN_PICK_ERROR_SUFFIXES = [
-  'DeveloperError: This object was destroyed,',
-  "TypeError: Can't access property _target, v3 is undefined",
-  "TypeError: Cannot read properties of undefined (reading '_target')",
-] as const;
-
-/**
- * Returns whether the given error thrown by `Scene.pickPosition` is one of
- * the known, expected/transient picking failures (see
- * {@link KNOWN_PICK_ERROR_SUFFIXES}), meaning it's safe to fall back to a
- * less accurate pick method instead of propagating the exception.
- */
-export function isKnownScenePickingError(e: unknown): boolean {
-  const message = String(e);
-  return KNOWN_PICK_ERROR_SUFFIXES.some((suffix) => message.startsWith(suffix));
+export function handleScenePickingError(e: unknown): void {
+  console.warn(
+    '[pick] Scene.pickPosition/pick threw; degrading gracefully for this call.',
+    e,
+  );
 }
 
 export class PickService extends BaseService {
@@ -91,10 +82,8 @@ export class PickService extends BaseService {
     try {
       return this.pickWithScene(Cartesian2.clone(position));
     } catch (e) {
-      if (isKnownScenePickingError(e)) {
-        return this.pickWithMath(position);
-      }
-      throw e;
+      handleScenePickingError(e);
+      return this.pickWithMath(position);
     }
   }
 

--- a/ui/src/viewer.ts
+++ b/ui/src/viewer.ts
@@ -88,7 +88,18 @@ export async function setupViewer(container: Element) {
   };
   const viewer = new Viewer(container, {
     contextOptions: contextOptions,
-    showRenderLoopErrors: false,
+    // CesiumWidget's internal render loop wraps its own per-frame
+    // `render()`/`resize()` calls in a try/catch that runs *before*
+    // `Scene.render()`'s own `tryAndCatchError` wrapping begins — so it also
+    // catches exceptions thrown by camera controllers (`ControllerHost.
+    // update()`), which `scene.renderError` below can never see. With
+    // `showRenderLoopErrors: false` that catch has no console logging of its
+    // own either: a render loop error stops the loop (and all camera
+    // interaction) forever with zero console output — exactly the
+    // silent-freeze bug this app hit before. Showing Cesium's default,
+    // unstyled error overlay is ugly, but an ugly, visible error is far
+    // better than an invisible, permanent freeze with no explanation at all.
+    showRenderLoopErrors: true,
     animation: false,
     baseLayerPicker: false,
     fullscreenButton: false,


### PR DESCRIPTION
The nadir/zenith gimbal-lock patch for ScreenSpaceTiltOrbitCameraController (tilt()/orbit()) rotated the camera's direction/up/right vectors every frame but never renormalized them, despite a comment claiming it did. Floating-point drift accumulated over sustained pan/orbit interaction until some later Cesium-internal computation hit a degenerate vector and threw.

That exception bypassed Cesium's own error handling entirely: Scene.render() calls controllerHost.update() before its tryAndCatchError wrapping begins, so the error propagated straight to CesiumWidget's outer render loop try/catch, which silently sets _useDefaultRenderLoop = false (stopping requestAnimationFrame forever) with no console output at all when showRenderLoopErrors is false - exactly matching the reported symptoms (frozen UI, idle CPU/GPU, zero console output, most common on Firefox/Edge).

Changes:
- patch-tilt-nadir-gimbal-lock.ts: actually renormalize the camera's basis vectors after each tilt()/orbit() rotation, and wrap both mutators in a guardCameraMutator() helper that logs and swallows any future exception instead of letting it escape into the render loop.
- approach-limited-zoom.controller.ts: split update() into a thin try/catch wrapper around the existing logic (updateUnsafe()), so a zoom-frame exception is logged and skipped instead of freezing the loop. This already caught a real, previously-uncaught Firefox Scene.pickPosition error in production.
- pick.service.ts: replace the brittle, hardcoded Scene.pickPosition error whitelist (isKnownScenePickingError) with a catch-all handleScenePickingError() that logs and lets every call site degrade gracefully. The old whitelist matched exact error text that differs by browser engine and has changed across Firefox versions/builds, so it silently stopped matching new variants; catching everything removes that fragility entirely. Updated all call sites (cesiumutils.ts, camera-controller.service.ts, approach-limited-zoom.controller.ts, control-zoom-debug.element.ts) accordingly.
- viewer.ts: enable showRenderLoopErrors so any future uncaught render-loop error (ours or Cesium's own) is shown via Cesium's standard, built-in error dialog instead of being silently swallowed. Showing an ugly error dialog is way better than silently swallowing the error or just printing it to console - it was the absence of any visible feedback that made the original freeze so hard to diagnose.